### PR TITLE
Remove browser version guard restriction

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,2 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
 end


### PR DESCRIPTION
Remove browser version guard restriction added by Rails as default.

This was introduced in Rails 7.2 but is too restrictive and blocks too many browser versions.

