### PR TITLE
Check for misspellings and typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   scan_ruby:
+    name: Check for vulnerabilities
     runs-on: ubuntu-latest
 
     steps:
@@ -23,6 +24,7 @@ jobs:
         run: bin/brakeman --no-pager
 
   lint:
+    name: Lint codebase
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -38,6 +40,7 @@ jobs:
         run: bin/rubocop -f github
 
   specs:
+    name: Run specs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  spelling:
+    name: Check spelling and typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v4
+    - name: Spell Check Repo
+      uses: crate-ci/typos@v1.29.7
+
   specs:
     name: Run specs
     runs-on: ubuntu-latest

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["spec/fixtures/vcr_cassettes/"]

--- a/app/views/layouts/_dfe_footer.html.erb
+++ b/app/views/layouts/_dfe_footer.html.erb
@@ -54,7 +54,7 @@
 
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <h2 class="govuk-visually-hidden">Give Feeedback</h2>
+        <h2 class="govuk-visually-hidden">Give Feedback</h2>
         <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
           <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
         </svg>


### PR DESCRIPTION
This uses the [typos] spelling checker to check the codebase as part of the build.

[typos]: https://github.com/crate-ci/typos