### PR TITLE
Set back link on solution page to referer

### DIFF
--- a/app/views/solutions/show.html.erb
+++ b/app/views/solutions/show.html.erb
@@ -2,7 +2,7 @@
   @page_section_title = t(".section_title")
   @page_title = @solution.title
   @page_description = @solution.description
-  @page_back_link = category_path(@category)
+  @page_back_link = request.referer || category_path(@category)
 %>
 
 <%= render_markdown_to_html(@solution.summary) %>


### PR DESCRIPTION
The backlink on the solution show page is currently set to its category page.

If a user selects some subcategory filters on the category page, then navigates to a solution page and clicks back, they will lose all the filters they selected.

This PR fixes that by setting the back link to the referer, with the category page as the fallback.