### PR TITLE
- Design changes to FB-127 

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -9,7 +9,9 @@ $govuk-assets-path: "/";
 .dfe-page-hero {
   color: #fff;
 }
-
+.header_description {
+  color: #ccd8e1;
+}
 .page-with-sidebar {
   background-color: #fff !important;
   flex-direction: column;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   rescue_from ContentfulRecordNotFoundError, with: :record_not_found
+  before_action :enable_search_in_header
 
 private
 
   def record_not_found(exception)
     @message = exception.message || "Record not found"
     render template: "errors/not_found", status: :not_found
+  end
+
+  def enable_search_in_header
+    @show_search_in_header = true
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,6 @@
 class CategoriesController < ApplicationController
+  before_action :enable_search_in_header, except: :index
+
   def index
     @categories = Category.all
     render layout: "homepage"

--- a/app/views/shared/_dfe_header.html.erb
+++ b/app/views/shared/_dfe_header.html.erb
@@ -1,4 +1,4 @@
 <header class="dfe-header" role="banner">
-  <%= render "shared/dfe_logo_and_menu", locals: { show_search: true } %>
+  <%= render "shared/dfe_logo_and_menu" %>
   <%= render "shared/dfe_beta_banner" %>
 </header>

--- a/app/views/shared/_dfe_homepage_header.html.erb
+++ b/app/views/shared/_dfe_homepage_header.html.erb
@@ -9,9 +9,9 @@
             <h1 class="dfe-heading-xl">
               <%= t('header_title') %>
             </h1>
-            <p class="dfe-body-l">
+            <h1 class="dfe-body-l header_description">
               <%= t('header_description') %>
-            </p>
+            </h1>
             <%= render "shared/dfe_search" %>
           </div>
         </div>

--- a/app/views/shared/_dfe_logo_and_menu.html.erb
+++ b/app/views/shared/_dfe_logo_and_menu.html.erb
@@ -11,7 +11,7 @@
         <a href="/TODO" class="govuk-link govuk-link--inverse"><%= t(".about_us") %></a>
       </li>
     </ul>
-    <%= render "shared/dfe_search" if defined? :show_search %>
+    <%= render "shared/dfe_search" if defined? local_assigns[:locals][:show_search] %>
     <div class="dfe-header__menu">
       <button class="dfe-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-expanded="false"><%= t(".menu") %></button>
     </div>

--- a/app/views/shared/_dfe_logo_and_menu.html.erb
+++ b/app/views/shared/_dfe_logo_and_menu.html.erb
@@ -11,7 +11,7 @@
         <a href="/TODO" class="govuk-link govuk-link--inverse"><%= t(".about_us") %></a>
       </li>
     </ul>
-    <%= render "shared/dfe_search" if defined? local_assigns[:locals][:show_search] %>
+    <%= render "shared/dfe_search" if @show_search_in_header %>
     <div class="dfe-header__menu">
       <button class="dfe-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-expanded="false"><%= t(".menu") %></button>
     </div>


### PR DESCRIPTION
- Homepage Header Description - Font size: H3, bold. Colour: CCD8E1
- Changes to the :show_search locals check to show the search bar for all other pages except the homepage on the top right portion of the header