### PR TITLE
Add placeholder link on solution details page

### DIFF
--- a/app/views/solutions/show.html.erb
+++ b/app/views/solutions/show.html.erb
@@ -7,3 +7,4 @@
 
 <%= render_markdown_to_html(@solution.summary) %>
 
+<%= link_to "Visit the #{h(@solution.title)} website", "", class: "govuk-button" %>


### PR DESCRIPTION
This is a quick fix for a demo today. We will add the correct link in a separate PR.