### PR TITLE
Use the solution url on its show page link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,13 @@
 module ApplicationHelper
   include MarkdownHelper
   include SvgHelper
+
+  def safe_url(url)
+    return "#" unless url.is_a?(String)
+
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS) ? url : "#"
+  rescue URI::InvalidURIError
+    "#"
+  end
 end

--- a/app/views/solutions/show.html.erb
+++ b/app/views/solutions/show.html.erb
@@ -7,7 +7,7 @@
 
 <%= render_markdown_to_html(@solution.summary) %>
 
-<%= link_to "Visit the #{h(@solution.title)} website", safe_url(@solution.url), class: "govuk-button" %>
+<%= link_to t(".cta", title: h(@solution.title)), safe_url(@solution.url), class: "govuk-button" %>
 
 <% content_for :sidebar do %>
   <%= render "shared/related_actions" %>

--- a/app/views/solutions/show.html.erb
+++ b/app/views/solutions/show.html.erb
@@ -7,8 +7,9 @@
 
 <%= render_markdown_to_html(@solution.summary) %>
 
-<%= link_to "Visit the #{h(@solution.title)} website", "", class: "govuk-button" %>
+<%= link_to "Visit the #{h(@solution.title)} website", safe_url(@solution.url), class: "govuk-button" %>
 
 <% content_for :sidebar do %>
   <%= render "shared/related_actions" %>
 <% end %>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,4 +85,5 @@ en:
       related_actions: Related actions
   solutions:
     show:
+      cta: Visit the %{title} website
       section_title: Framework


### PR DESCRIPTION
The link to a solution's website was added in a hurry for a demo. This PR adds the missing url.

It assumes the url exists but we need to add a `required` constraint on the url field in the Solution model in Contentful.
