### PR TITLE
Add support for content pages

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -23,6 +23,15 @@ $govuk-assets-path: "/";
   margin: 0;
 }
 
+.sidebar a {
+  color: #1d70b8;
+  &:hover,
+  &:active,
+  &:focus {
+    color: #003078;
+  }
+}
+
 .govuk-footer__copyright-logo {
   background-image: url("govuk-frontend/govuk-crest.svg");
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,5 @@
+class PagesController < ApplicationController
+  def show
+    @page = Page.find_by_slug!(params[:slug])
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,0 +1,25 @@
+class Page
+  include ActiveModel::Model
+
+  attr_reader :id, :title, :body, :description, :slug, :sidebar, :breadcrumbs
+
+  def initialize(entry)
+    @id = entry.id
+    @title = entry.fields[:title]
+    @body = entry.fields[:body]
+    @description = entry.fields[:description]
+    @slug = entry.fields[:slug]
+    @sidebar = entry.fields[:sidebar]
+    @breadcrumbs = entry.fields[:breadcrumbs]
+  end
+
+  def self.find_by_slug!(slug)
+    entry = ContentfulClient.entries(
+      content_type: "page",
+      'fields.slug': slug
+    ).first
+    raise ContentfulRecordNotFoundError, "Page: '#{slug}' not found" unless entry
+
+    new(entry)
+  end
+end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -54,3 +54,7 @@
     </p>
   </div>
 <% end %>
+
+<% content_for :sidebar do %>
+  <%= render "shared/related_actions" %>
+<% end %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,14 @@
+<h1><%= @page.title %></h1>
+
+<p>
+  <%= @page.description %>
+</p>
+
+
+<div>
+  <%= render_markdown_to_html(@page.body) %>
+</div>
+
+<% content_for :sidebar do %>
+  <%= render_markdown_to_html(@page.sidebar) %>
+<% end %>

--- a/app/views/shared/_dfe_sidebar.html.erb
+++ b/app/views/shared/_dfe_sidebar.html.erb
@@ -1,16 +1,3 @@
 <div class="sidebar govuk-grid-column-one-third govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-  <h3> <%= t(".related_actions") %> </h3>
-  <p>
-  <ul>
-    <li><%= govuk_link_to "Plan technology for your school", root_path %></li>
-    <li><%= govuk_link_to "Read guidance on buying ICT", root_path %></li>
-    <li><%= govuk_link_to "Read guidance on buying printing devices", root_path %></li>
-  </ul>
-  </p>
-  <h3> <%= t(".catalogues") %> </h3>
-  <p>
-  <ul>
-    <li><%= govuk_link_to "View Everything ICT catalogue", root_path %></li>
-  </ul>
-  </p>
+  <%= yield(:sidebar) %>
 </div>

--- a/app/views/shared/_related_actions.html.erb
+++ b/app/views/shared/_related_actions.html.erb
@@ -1,8 +1,1 @@
 <h3> <%= t("shared.dfe_sidebar.related_actions") %> </h3>
-<div>
-<ul>
-  <li><%= govuk_link_to "Plan technology for your school", root_path %></li>
-  <li><%= govuk_link_to "Read guidance on buying ICT", root_path %></li>
-  <li><%= govuk_link_to "Read guidance on buying printing devices", root_path %></li>
-</ul>
-</div>

--- a/app/views/shared/_related_actions.html.erb
+++ b/app/views/shared/_related_actions.html.erb
@@ -1,0 +1,8 @@
+<h3> <%= t("shared.dfe_sidebar.related_actions") %> </h3>
+<div>
+<ul>
+  <li><%= govuk_link_to "Plan technology for your school", root_path %></li>
+  <li><%= govuk_link_to "Read guidance on buying ICT", root_path %></li>
+  <li><%= govuk_link_to "Read guidance on buying printing devices", root_path %></li>
+</ul>
+</div>

--- a/app/views/solutions/show.html.erb
+++ b/app/views/solutions/show.html.erb
@@ -8,3 +8,7 @@
 <%= render_markdown_to_html(@solution.summary) %>
 
 <%= link_to "Visit the #{h(@solution.title)} website", "", class: "govuk-button" %>
+
+<% content_for :sidebar do %>
+  <%= render "shared/related_actions" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,6 @@ en:
       search: Search
       search_this_website: Search this website
     dfe_sidebar:
-      catalogues: Catalogues
       related_actions: Related actions
   solutions:
     show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   root "categories#index"
   resources :categories, only: %i[show index], param: :slug
   resources :solutions, only: %i[show], param: :slug
+  get "/:slug", to: "pages#show", as: :page
   get "/search", to: "search#index"
 end

--- a/spec/fixtures/vcr_cassettes/Page/_find_by_slug_/when_page_does_not_exist/raises_ContentfulRecordNotFoundError.yml
+++ b/spec/fixtures/vcr_cassettes/Page/_find_by_slug_/when_page_does_not_exist/raises_ContentfulRecordNotFoundError.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cdn.contentful.com/spaces/FAKE_SPACE_ID/environments/master/entries?content_type=page&fields.slug=non-existent
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful.rb/2.17.1; platform ruby/3.4.1; os macOS/24;
+      Authorization:
+      - Bearer FAKE_API_KEY
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
+      Host:
+      - cdn.contentful.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Cf-Space-Id:
+      - FAKE_SPACE_ID
+      Cf-Environment-Id:
+      - master
+      Cf-Environment-Uuid:
+      - 1bae0c6c-9bf9-4c44-9420-7099ae5e9248
+      Cf-Organization-Id:
+      - 3za11RVJBwLIPn20QJ67Gq
+      X-Contentful-Route:
+      - "/spaces/:space/environments/:environment/entries"
+      Etag:
+      - '"7787070206043126912"'
+      X-Content-Type-Options:
+      - nosniff
+      Contentful-Api:
+      - cda
+      Server:
+      - Contentful
+      X-Contentful-Region:
+      - us-east-1
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Resource-Resolution
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '86400'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,OPTIONS
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Thu, 13 Mar 2025 21:38:09 GMT
+      X-Served-By:
+      - cache-ewr-kewr1740040-EWR, cache-lhr-egll1980071-LHR
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1741901889.416588,VS0,VE132
+      X-Cache:
+      - MISS
+      X-Contentful-Request-Id:
+      - d9408388-e06b-4262-90f4-11750dbe3ff1
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sys":{"type":"Array"},"total":0,"skip":0,"limit":100,"items":[]}
+
+        '
+  recorded_at: Thu, 13 Mar 2025 21:38:09 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Page/_find_by_slug_/when_page_exists/returns_the_page.yml
+++ b/spec/fixtures/vcr_cassettes/Page/_find_by_slug_/when_page_exists/returns_the_page.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cdn.contentful.com/spaces/FAKE_SPACE_ID/environments/master/entries?content_type=page&fields.slug=devtest
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful.rb/2.17.1; platform ruby/3.4.1; os macOS/24;
+      Authorization:
+      - Bearer FAKE_API_KEY
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
+      Host:
+      - cdn.contentful.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1168'
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Cf-Space-Id:
+      - FAKE_SPACE_ID
+      Cf-Environment-Id:
+      - master
+      Cf-Environment-Uuid:
+      - 1bae0c6c-9bf9-4c44-9420-7099ae5e9248
+      Cf-Organization-Id:
+      - 3za11RVJBwLIPn20QJ67Gq
+      X-Contentful-Route:
+      - "/spaces/:space/environments/:environment/entries"
+      Etag:
+      - W/"9532722871338998881"
+      X-Content-Type-Options:
+      - nosniff
+      Contentful-Api:
+      - cda
+      Content-Encoding:
+      - gzip
+      Server:
+      - Contentful
+      X-Contentful-Region:
+      - us-east-1
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Resource-Resolution
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '86400'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,OPTIONS
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '3310'
+      Date:
+      - Thu, 13 Mar 2025 21:38:09 GMT
+      X-Served-By:
+      - cache-ewr-kewr1740073-EWR, cache-lhr-egll1980064-LHR
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1741901889.331484,VS0,VE1
+      X-Cache:
+      - HIT
+      X-Contentful-Request-Id:
+      - 034a9225-3b72-4f79-9c63-70377ff31def
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA51VzW7cNhC+9ykI+dAGWPnfLro3p3WbQ1Cktdug9fpAiSOJWYkUSErbrWEg79BTXy9P0m9Iea04BoL0tpLIb+b7mdm7zG99trzLwranbJldOCe32f0iCzbINlseLTK/1n22PFxkre50wKtD/NaBOty7ucs6ClLJICOIrPnl7SIrrSmpD/EJaFMR38sSVe6eFH2tzTpjfLO+Tm1cxYMoo9CTPS99c3Ry/u7oncvugRbfnp5f1Re/bH4aT16/CvXpS//dxeWvR7gzMbk0wW3xWDqSgdQFOs+OD4/P8sOT/Ojk+vhweXq8PDvbPz3/9k8cG3qQ+PwxMqN21nRkgLfjERvqpA/kHhv4lNXl7DLz6Iei1b4h9Ts5r63JlqeLzNGo0wO0h4wBpZIqn5ft+9nxSaZe1hRFa20pW7aYTP7bFVtcaWpVMl+H+OkHGsU1+SDe8K1FpsiXTvch9pa9pQ/v/21bUeuRxNYOIjQk0GGlFcFtEawohi3edH2rpQkty19YtcXdvT3xEp8aa702tRj8IiJsNPAKMlTpICpnu+XKrEwuZEKhQO0W74mEJzdqFPnw/h+xIaGsQTMBiNLVJCrrhDRbYSthB/dw2Au8Dta2fmVk3zs7kgKa7Ghj3dpPWMABH7TmycTbsxOldFQNLZoAOQYAVVFbq8Qo24EWaHMkx4yivOhBCSNZLzz4oYcQsJYZ6a6XLmg+o+ZE+MknOa2JihZsgLNDSLQg02LOGF2wWGBWU4ikKyIfxYOs3MozVJOmwQ2IqAIBNB0z/ETW5G8n19B7cLErx7RLPMTj2j/ay5iKlC55boTvqQQ77cNMV5grvde1QZ+C/urJBRayobaf7A/NJ0UY929yVkD8gjVhh5+g7hA6ggixzXSM44OsvbIbaJbosNcIWqq0Mm8ppg5By4UjT9KVTfQNnZL30YJOujUFPrErFKOLjH9sEMiks0zrsRdDpKLrcBecJ4MdD0twsozIG4cdmlrX2AshpoZhMPCK3HR7lo0GnPDZDSbdIo5gusUWofdICZ/lR57xbPCs6Solo3caju3I1Yhaj0mphGeOrY9DHCw0b1Ibu3mPyeyZAE9iow1cYeWCBsDc14ICViGkMdgjzxi8Mn9Mwx9tqCWXEhJxYX21QcvdpEcjo7+CJeUacbtgLzyDmu8mFOujhbHJ1hLpBeGU0IrjykKDb4zNzqrHmAyRDHcia6we5tdhEWJ7RoV3HQTp19hjfuAAefHgByYwWZjEKRsq1zyWCmPEQ4RZ5W0V2yq3jOiJ1nNvZsP0sC2AnzaF4gtxQhUGjv8oYlMFmh2lbmXRprXBYURVjxXs26HGClY0BhjIL7DFCuniWt4TPw4uyj+TfWVu0gR9jc3II8ADntJx+00TQu+XBwcxIG2PtKAOKE0H9kuJVYeZ38ea2R/WB8htvqGR8gSUT+de8KjevIZNCGyBdce5A9KXF2CrTR4x8oSRsH+mTbIAxSH7lwMbAOQIeJ4AEuobR7mj0jrsPuyYQhvp/gd2P4OBPAnmBf6pb++/+g+UKWjKlQkAAA==
+  recorded_at: Thu, 13 Mar 2025 21:38:09 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Page/_initialize/sets_the_attributes.yml
+++ b/spec/fixtures/vcr_cassettes/Page/_initialize/sets_the_attributes.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cdn.contentful.com/spaces/FAKE_SPACE_ID/environments/master/entries?content_type=page&fields.slug=devtest
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful.rb/2.17.1; platform ruby/3.4.1; os macOS/24;
+      Authorization:
+      - Bearer FAKE_API_KEY
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
+      Host:
+      - cdn.contentful.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1168'
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Cf-Space-Id:
+      - FAKE_SPACE_ID
+      Cf-Environment-Id:
+      - master
+      Cf-Environment-Uuid:
+      - 1bae0c6c-9bf9-4c44-9420-7099ae5e9248
+      Cf-Organization-Id:
+      - 3za11RVJBwLIPn20QJ67Gq
+      X-Contentful-Route:
+      - "/spaces/:space/environments/:environment/entries"
+      Etag:
+      - W/"9532722871338998881"
+      X-Content-Type-Options:
+      - nosniff
+      Contentful-Api:
+      - cda
+      Content-Encoding:
+      - gzip
+      Server:
+      - Contentful
+      X-Contentful-Region:
+      - us-east-1
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Resource-Resolution
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '86400'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,OPTIONS
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Mar 2025 21:38:09 GMT
+      Age:
+      - '3310'
+      X-Served-By:
+      - cache-ewr-kewr1740073-EWR, cache-lhr-egll1980088-LHR
+      X-Cache-Hits:
+      - 0, 7
+      X-Timer:
+      - S1741901890.664111,VS0,VE0
+      X-Cache:
+      - HIT
+      X-Contentful-Request-Id:
+      - e3accca1-04c3-41a1-9672-cdb867553fb8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA51VzW7cNhC+9ykI+dAGWPnfLro3p3WbQ1Cktdug9fpAiSOJWYkUSErbrWEg79BTXy9P0m9Iea04BoL0tpLIb+b7mdm7zG99trzLwranbJldOCe32f0iCzbINlseLTK/1n22PFxkre50wKtD/NaBOty7ucs6ClLJICOIrPnl7SIrrSmpD/EJaFMR38sSVe6eFH2tzTpjfLO+Tm1cxYMoo9CTPS99c3Ry/u7oncvugRbfnp5f1Re/bH4aT16/CvXpS//dxeWvR7gzMbk0wW3xWDqSgdQFOs+OD4/P8sOT/Ojk+vhweXq8PDvbPz3/9k8cG3qQ+PwxMqN21nRkgLfjERvqpA/kHhv4lNXl7DLz6Iei1b4h9Ts5r63JlqeLzNGo0wO0h4wBpZIqn5ft+9nxSaZe1hRFa20pW7aYTP7bFVtcaWpVMl+H+OkHGsU1+SDe8K1FpsiXTvch9pa9pQ/v/21bUeuRxNYOIjQk0GGlFcFtEawohi3edH2rpQkty19YtcXdvT3xEp8aa702tRj8IiJsNPAKMlTpICpnu+XKrEwuZEKhQO0W74mEJzdqFPnw/h+xIaGsQTMBiNLVJCrrhDRbYSthB/dw2Au8Dta2fmVk3zs7kgKa7Ghj3dpPWMABH7TmycTbsxOldFQNLZoAOQYAVVFbq8Qo24EWaHMkx4yivOhBCSNZLzz4oYcQsJYZ6a6XLmg+o+ZE+MknOa2JihZsgLNDSLQg02LOGF2wWGBWU4ikKyIfxYOs3MozVJOmwQ2IqAIBNB0z/ETW5G8n19B7cLErx7RLPMTj2j/ay5iKlC55boTvqQQ77cNMV5grvde1QZ+C/urJBRayobaf7A/NJ0UY929yVkD8gjVhh5+g7hA6ggixzXSM44OsvbIbaJbosNcIWqq0Mm8ppg5By4UjT9KVTfQNnZL30YJOujUFPrErFKOLjH9sEMiks0zrsRdDpKLrcBecJ4MdD0twsozIG4cdmlrX2AshpoZhMPCK3HR7lo0GnPDZDSbdIo5gusUWofdICZ/lR57xbPCs6Solo3caju3I1Yhaj0mphGeOrY9DHCw0b1Ibu3mPyeyZAE9iow1cYeWCBsDc14ICViGkMdgjzxi8Mn9Mwx9tqCWXEhJxYX21QcvdpEcjo7+CJeUacbtgLzyDmu8mFOujhbHJ1hLpBeGU0IrjykKDb4zNzqrHmAyRDHcia6we5tdhEWJ7RoV3HQTp19hjfuAAefHgByYwWZjEKRsq1zyWCmPEQ4RZ5W0V2yq3jOiJ1nNvZsP0sC2AnzaF4gtxQhUGjv8oYlMFmh2lbmXRprXBYURVjxXs26HGClY0BhjIL7DFCuniWt4TPw4uyj+TfWVu0gR9jc3II8ADntJx+00TQu+XBwcxIG2PtKAOKE0H9kuJVYeZ38ea2R/WB8htvqGR8gSUT+de8KjevIZNCGyBdce5A9KXF2CrTR4x8oSRsH+mTbIAxSH7lwMbAOQIeJ4AEuobR7mj0jrsPuyYQhvp/gd2P4OBPAnmBf6pb++/+g+UKWjKlQkAAA==
+  recorded_at: Thu, 13 Mar 2025 21:38:09 GMT
+recorded_with: VCR 6.3.1

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Page, :vcr, type: :model do
+  describe "#initialize" do
+    subject(:page) { described_class.new(entry) }
+
+    let(:entry) do
+      ContentfulClient.entries(
+        content_type: "page",
+        "fields.slug": "devtest"
+      ).first
+    end
+
+    it "sets the attributes" do
+      expect(page).to have_attributes(
+        id: be_present,
+        title: be_present,
+        body: be_present,
+        description: be_present,
+        slug: be_present,
+        sidebar: be_present
+      )
+    end
+  end
+
+  describe ".find_by_slug!" do
+    subject(:find_page) { described_class.find_by_slug!(slug) }
+
+    context "when page exists" do
+      let(:slug) { "devtest" }
+
+      it "returns the page" do
+        expect(find_page).to be_a(described_class)
+        expect(find_page.slug).to eq(slug)
+      end
+    end
+
+    context "when page does not exist" do
+      let(:slug) { "non-existent" }
+
+      it "raises ContentfulRecordNotFoundError" do
+        expect { find_page }.to raise_error(ContentfulRecordNotFoundError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new `Page` model corresponding to the same in Contentful. It includes the following:

- Page model and specs
- PagesController and show page
- Refactored sidebar logic to display sidebar content specific to each Page
- The existing placeholder sidebar content for categories and solutions has been moved to a new partial. This needs to be updated to use real content but that's outside the scope of this PR.

