### PR TITLE
Fix: Only check for subcategories presence to show filters

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -39,19 +39,18 @@
       <%= render "categories/filter_labels" %>
     <% end %>
   </div>
+<% end %>
 
-  <h2><%= t(".title") %></h2>
-  <p><%= t(".standfirst") %></p>
+<h2><%= t(".title") %></h2>
+<p><%= t(".standfirst") %></p>
 
-  <% @solutions.each do |solution| %>
-    <div class="solution">
-      <h3>
-        <%= govuk_link_to solution.title, solution_path(solution.slug) %>
-      </h3>
-      <p>
-        <%= solution.description %>
-      </p>
-    </div>
-  <% end %>
-
+<% @solutions.each do |solution| %>
+  <div class="solution">
+    <h3>
+      <%= govuk_link_to solution.title, solution_path(solution.slug) %>
+    </h3>
+    <p>
+      <%= solution.description %>
+    </p>
+  </div>
 <% end %>


### PR DESCRIPTION
Fix for a view bug which hides all solutions when no `subcategories` are present.

Even when a category has solutions, they are not shown because of a misplaced `<% end %>` on a condition:

<img width="856" alt="Screenshot 2025-03-16 at 10 33 13 pm" src="https://github.com/user-attachments/assets/ae2372e4-5add-4d4b-ac80-6581ebaad126" />
