### PR TITLE
FB-161 Fix category tile height and truncate text when it's too long

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -222,6 +222,8 @@ footer {
     display: -webkit-box;
     -webkit-line-clamp: 5;
     -webkit-box-orient: vertical;
+    word-wrap: break-word;
+    hyphens: auto;
   }
 }
 

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -191,7 +191,7 @@ footer {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 16px;
-  padding: 16px;
+  padding: 16px 0;
 }
 
 .dfe-card {

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -186,3 +186,47 @@ footer {
 .search-button:hover {
   background: #003078;
 }
+
+.dfe-grid-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+  padding: 16px;
+}
+
+.dfe-card {
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  height: 300px;
+
+  .title {
+    height: 50px;
+    padding-bottom: 10px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    line-clamp: 2;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  .description {
+    margin: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    line-clamp: 5;
+    display: -webkit-box;
+    -webkit-line-clamp: 5;
+    -webkit-box-orient: vertical;
+  }
+}
+
+.dfe-card-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,9 +1,9 @@
 <div class="dfe-card">
     <div class="dfe-card-container">
-      <h3 class="govuk-heading-m">
+      <h3 class="govuk-heading-m title">
         <%= link_to category.title, category_path(category), class: "govuk-link govuk-link--no-visited-state dfe-card-link--header" %>
       </h3>
-      <p>
+      <p class="description">
         <%= category.description %>
       </p>
     </div>


### PR DESCRIPTION
JIRA ticket - https://dfedigital.atlassian.net/jira/software/projects/FB/boards/258?selectedIssue=FB-161

- Fix category tile height

- Truncate title and description text when it's more than 5 lines long.

- Hyphenate long words

- Fix left alignment of grid

<img width="1423" alt="Screenshot 2025-03-18 at 1 58 42 pm" src="https://github.com/user-attachments/assets/b63e8e2c-0807-46a5-94f0-d311a135ff05" />
