### PR TITLE
Update nav links in header

### DIFF
--- a/app/views/shared/_dfe_logo_and_menu.html.erb
+++ b/app/views/shared/_dfe_logo_and_menu.html.erb
@@ -43,32 +43,8 @@
         </a>
       </li>
       <li class="dfe-header__navigation-item ">
-        <a class="dfe-header__navigation-link" href="/TODO">
-          <%= t(".offers") %>
-          <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-          </svg>
-        </a>
-      </li>
-      <li class="dfe-header__navigation-item ">
-        <a class="dfe-header__navigation-link" href="/TODO">
-          <%= t(".training") %>
-          <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-          </svg>
-        </a>
-      </li>
-      <li class="dfe-header__navigation-item ">
-        <a class="dfe-header__navigation-link" href="/TODO">
+        <a class="dfe-header__navigation-link" href="/find-a-dfe-approved-buying-solution">
           <%= t(".guidance") %>
-          <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-          </svg>
-        </a>
-      </li>
-      <li class="dfe-header__navigation-item ">
-        <a class="dfe-header__navigation-link" href="/TODO">
-          <%= t(".support") %>
           <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
             <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
           </svg>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,9 +74,6 @@ en:
       guidance: Guidance
       home: Home
       menu: Menu
-      offers: Offers
-      support: Support
-      training: Training
     dfe_search:
       close_search: Close search
       search: Search


### PR DESCRIPTION
This PR updates the navigation links in the header as per the latest design.

- Remove links we no longer need

- Update Guidance link

<img width="816" alt="Screenshot 2025-03-18 at 5 39 54 pm" src="https://github.com/user-attachments/assets/ddbd39f9-90e7-43a7-ad35-c7344e412ef8" />

<img width="702" alt="Screenshot 2025-03-18 at 5 40 02 pm" src="https://github.com/user-attachments/assets/fc052da4-3f3a-4672-be4a-8d16d5a7dd4b" />
