### PR TITLE
Remove category attribute from Subcategory model

### DIFF
--- a/app/models/subcategory.rb
+++ b/app/models/subcategory.rb
@@ -1,7 +1,7 @@
 class Subcategory
   include ActiveModel::Model
 
-  attr_reader :id, :title, :slug, :category
+  attr_reader :id, :title, :slug
 
   def initialize(entry)
     @id = entry.id


### PR DESCRIPTION
The category attribute is not needed in the Subcategory model. This PR removes it.