### PR TITLE
Update back links

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   rescue_from ContentfulRecordNotFoundError, with: :record_not_found
-  before_action :enable_search_in_header
+  before_action :enable_search_in_header, :set_default_back_link
 
 private
 
@@ -13,4 +13,10 @@ private
   def enable_search_in_header
     @show_search_in_header = true
   end
+
+  # rubocop:disable Naming/MemoizedInstanceVariableName
+  def set_default_back_link
+    @page_back_link ||= root_path
+  end
+  # rubocop:enable Naming/MemoizedInstanceVariableName
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
   def show
     @page = Page.find_by_slug!(params[:slug])
+    @page_back_link = request.referer || root_path
   end
 end

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,3 +1,7 @@
+<% 
+  @page_back_link = request.referer || root_path
+%>
+
 <h1><%= @page.title %></h1>
 
 <p>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,7 +1,3 @@
-<% 
-  @page_back_link = request.referer || root_path
-%>
-
 <h1><%= @page.title %></h1>
 
 <p>


### PR DESCRIPTION
Set the default back link to the root path. The back link should work even if a page doesn't have a custom back link set.

Set back link for content pages.