### PR TITLE
Fix design issues

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -19,6 +19,19 @@ $govuk-assets-path: "/";
   flex-direction: column;
 }
 
+h1.govuk-heading {
+  margin-bottom: 30px;
+}
+
+.page-description {
+  padding-bottom: 10px;
+  font-size: 24px;
+}
+
+.sidebar {
+  margin-top: 60px;
+}
+
 .sidebar > ul {
   list-style: none;
   padding: 0;
@@ -146,6 +159,11 @@ footer {
   }
 }
 
+.section-title {
+  color: #525c61;
+  padding: 10px 0;
+  font-size: 18px;
+}
 .search-results-section{
   border-bottom: 1px solid #b1b4b6;
   margin-top: 10px;

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -8,6 +8,16 @@ $govuk-assets-path: "/";
 .dfe-page-hero {
   color: #fff;
 }
+
+.dfe-header__navigation-item {
+  padding: 12px 0;
+  margin: 0 30px 0 0;
+  a {
+    padding: 0;
+    margin: 0;
+  }
+}
+
 .header_description {
   color: #ccd8e1;
   font-weight: 700;

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -308,7 +308,13 @@ footer {
 }
 
 .govuk-footer__list--inline {
+  max-width: 800px;
   display: flex;
   flex-wrap: wrap;
   gap: 15px;
+}
+
+.govuk-footer__licence-description {
+  margin-top: 10px;
+  max-width: 500px;
 }

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -18,6 +18,10 @@ $govuk-assets-path: "/";
   }
 }
 
+a.underlined {
+  text-decoration: underline;
+}
+
 .header_description {
   color: #ccd8e1;
   font-weight: 700;
@@ -174,6 +178,27 @@ footer {
   padding: 10px 0;
   font-size: 18px;
 }
+
+.dfe-header__search {
+  text-align: left;
+}
+
+@media (min-width: 53em) {
+  .dfe-search__input {
+    width: 450px;
+  }
+}
+
+@media (min-width: 75em) {
+  .dfe-search__input {
+    width: 650px;
+  }
+}
+
+.dfe-search__submit {
+  background: #a2d5f5;
+}
+
 .search-results-section{
   border-bottom: 1px solid #b1b4b6;
   margin-top: 10px;

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -10,6 +10,9 @@ $govuk-assets-path: "/";
 }
 .header_description {
   color: #ccd8e1;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1.33333;
 }
 .page-with-sidebar {
   background-color: #fff !important;

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -5,8 +5,17 @@ $govuk-assets-path: "/";
 @use "../node_modules/govuk-frontend/dist/govuk/all" as govuk;
 @use "../node_modules/dfe-frontend/packages/dfefrontend" as dfefrontend;
 
+.dfe-header {
+  color: #fff;
+}
+
 .dfe-page-hero {
   color: #fff;
+}
+
+.dfe-header__navigation.js-show .dfe-header__navigation-item.dfe-header__navigation-item--current a {
+  color: #003a69;
+  font-weight: 700;
 }
 
 .dfe-header__navigation-item {
@@ -66,6 +75,7 @@ h1.govuk-heading {
 }
 
 .beta-banner {
+  color: #0b0c0c;
   background-color: #f6f6f6;
   padding: 10px;
 }
@@ -181,6 +191,16 @@ footer {
 
 .dfe-header__search {
   text-align: left;
+}
+
+.dfe-header__search_narrow  {
+  .dfe-search__input {
+  width: 300px;
+  }
+
+  .dfe-search__submit {
+    background: #f0f4f5;
+  }
 }
 
 @media (min-width: 53em) {

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,4 +1,4 @@
-<div class="dfe-width-container govuk-!-margin-top-4">
+<div class="govuk-!-margin-top-4">
   <h2 class="govuk-heading"><%= t(".title") %></h2>
   <p><%= t(".standfirst") %></p>
   <div class="dfe-grid-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,10 +6,9 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <%= govuk_back_link(href:  @page_back_link ) %>
-          <br/><br/>
-          <div><%= @page_section_title %></div>
-          <h2 class="govuk-heading"><%= @page_title %></h2>
-          <p>
+          <div class="section-title"><%= @page_section_title %></div>
+          <h1 class="govuk-heading"><%= @page_title %></h1>
+          <p class="page-description">
             <%= @page_description %>
           </p>
         </div>
@@ -20,7 +19,7 @@
   <div class="page-with-sidebar">
     <div class="dfe-width-container">
       <div class="blue-line"></div>
-      <div class="govuk-grid-column-two-thirds govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0 govuk-!-margin-top-4 govuk-!-margin-bottom-7">
         <%= yield %>
       </div>
       <%= render "shared/dfe_sidebar" %>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,25 +1,9 @@
 <%= render "shared/dfe_base" do %>
   <%= render "shared/dfe_homepage_header" %>
-
-    <div class="page-header">
-      <div class="dfe-width-container">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <div><%= @page_section_title %></div>
-            <h2 class="govuk-heading"><%= @page_title %></h2>
-            <p>
-              <%= @page_description %>
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-
   <div class="dfe-width-container">
     <div class="govuk-!-margin-top-7 govuk-!-margin-bottom-7">
       <%= yield %>
     </div>
   </div>
-
   <%= render "shared/dfe_footer" %>
 <% end %>

--- a/app/views/layouts/pages.html.erb
+++ b/app/views/layouts/pages.html.erb
@@ -3,7 +3,7 @@
 
   <div class="page-with-sidebar">
     <div class="dfe-width-container">
-      <div class="govuk-grid-column-two-thirds govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0 govuk-!-margin-top-7 govuk-!-margin-bottom-7">
         <%= yield %>
       </div>
       <%= render "shared/dfe_sidebar" %>

--- a/app/views/layouts/pages.html.erb
+++ b/app/views/layouts/pages.html.erb
@@ -1,0 +1,15 @@
+<%= render "shared/dfe_base" do %>
+  <%= render "shared/dfe_header" %>
+
+  <div class="page-with-sidebar">
+    <div class="dfe-width-container">
+      <div class="govuk-grid-column-two-thirds govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        <%= yield %>
+      </div>
+      <%= render "shared/dfe_sidebar" %>
+    </div>
+  </div>
+
+  <%= render "shared/dfe_footer" %>
+ <% end %>
+

--- a/app/views/layouts/search.html.erb
+++ b/app/views/layouts/search.html.erb
@@ -16,7 +16,7 @@
 
   <div class="page-with-sidebar">
     <div class="dfe-width-container">
-      <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
+      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0 govuk-!-margin-bottom-7">
         <%= yield %>
       </div>
     </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -8,6 +8,13 @@
       <div class="dfe-grid-column-full-width">
         <%= render "search/full_width_search_box" %>
       </div>
+
+      <% if !@solutions.any? && !@categories.any? %>
+        <h2><%=t("search.no_results.title") %></h2>
+        <p class="govuk-body"><%=t("search.no_results.description") %></p>
+        <h5><%= govuk_link_to t("search.no_results.cta"), root_path %></h5>
+      <% end %>
+
       <% if @solutions.any? %>
         <div class="search-results-section" %>
           <h2 class="govuk-heading-m">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,19 +2,12 @@
   @page_back_link = root_path
 %>
 
-<%= render "shared/dfe_base" do %>
   <div class="dfe-width-container">
     <main class="govuk-main-wrapper">      
       <h1 class="govuk-heading-l"><%= t("search.title") %></h1>
-
-      <div>
-        <div class="dfe-grid-row">
-          <div class="dfe-grid-column-full-width">
-            <%= render "search/full_width_search_box" %>
-          </div>
-        </div>
+      <div class="dfe-grid-column-full-width">
+        <%= render "search/full_width_search_box" %>
       </div>
-
       <% if @solutions.any? %>
         <div class="search-results-section" %>
           <h2 class="govuk-heading-m">
@@ -68,4 +61,3 @@
       <% end %>
     </main>
   </div>
-<% end %>

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -20,14 +20,14 @@
             <a class="govuk-footer__link" href="/terms-and-conditions"><%= t(".terms_and_conditions") %></a>
           </li>
         </ul>
-        <%= govuk_footer_licence_logo %>
-        <span class="govuk-footer__licence-description">
+        <div><%= govuk_footer_licence_logo %></div>
+        <div class="govuk-footer__licence-description">
           <%= t(".licensing_html",
                 ogl3: link_to(t(".ogl3"),
                               "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
                               class: "govuk-footer__link",
                               rel: "license")) %>
-        </span>
+        </div>
       </div>
       <div class="govuk-footer__meta-item">
         <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"><%= t(".crown_copyright") %></a>

--- a/app/views/shared/_dfe_homepage_header.html.erb
+++ b/app/views/shared/_dfe_homepage_header.html.erb
@@ -9,9 +9,9 @@
             <h1 class="dfe-heading-xl">
               <%= t('header_title') %>
             </h1>
-            <p class="dfe-body-l header_description">
+            <h3 class="dfe-body-l header_description">
               <%= t('header_description') %>
-            </p>
+            </h3>
             <%= render "shared/dfe_search" %>
           </div>
         </div>

--- a/app/views/shared/_dfe_homepage_header.html.erb
+++ b/app/views/shared/_dfe_homepage_header.html.erb
@@ -1,26 +1,22 @@
 <header class="dfe-header" role="banner">
   <%= render "shared/dfe_logo_and_menu" %>
-
-  <div class="dfe-width-container dfe-header__link--service">
-    <section class="dfe-page-hero">
-      <div class="dfe-width-container">
-        <div class="dfe-grid-row">
-          <div class="dfe-grid-column-two-thirds">
-            <h1 class="dfe-heading-xl">
-              <%= t('header_title') %>
-            </h1>
-            <h3 class="dfe-body-l header_description">
-              <%= t('header_description') %>
-            </h3>
-            <%= render "shared/dfe_search" %>
-          </div>
+  <section class="dfe-page-hero">
+    <div class="dfe-width-container">
+      <div class="dfe-grid-row">
+        <div class="dfe-grid-column-two-thirds govuk-!-padding-top-8">
+          <h1 class="dfe-heading-xl">
+            <%= t('header_title') %>
+          </h1>
+          <h3 class="dfe-body-l header_description">
+            <%= t('header_description') %>
+          </h3>
+          <%= render "shared/dfe_search" %>
         </div>
       </div>
-    </section>
-  </div>
-
+    </div>
+  </section>
   <div class="dfe-width-container dfe-header__service-name govuk-!-margin-top-4">
-    <a href="/" class="dfe-header__link--service"><%= t(".home_link") %></a>
+    <a href="/" class="dfe-header__link--service underlined"><%= t(".view_all_buying_options") %></a>
   </div>
 
   <%= render "shared/dfe_beta_banner" %>

--- a/app/views/shared/_dfe_homepage_header.html.erb
+++ b/app/views/shared/_dfe_homepage_header.html.erb
@@ -9,9 +9,9 @@
             <h1 class="dfe-heading-xl">
               <%= t('header_title') %>
             </h1>
-            <h1 class="dfe-body-l header_description">
+            <p class="dfe-body-l header_description">
               <%= t('header_description') %>
-            </h1>
+            </p>
             <%= render "shared/dfe_search" %>
           </div>
         </div>

--- a/app/views/shared/_dfe_logo_and_menu.html.erb
+++ b/app/views/shared/_dfe_logo_and_menu.html.erb
@@ -29,7 +29,7 @@
       </button>
     </p>
     <ul class="dfe-header__navigation-list">
-      <li class="dfe-header__navigation-item dfe-header__navigation-item--current">
+      <li class="dfe-header__navigation-item <%= 'dfe-header__navigation-item--current' if current_page?('/') %>">
         <a class="dfe-header__navigation-link" href="/">
           <%= t(".home") %>
           <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
@@ -37,7 +37,7 @@
           </svg>
         </a>
       </li>
-      <li class="dfe-header__navigation-item ">
+      <li class="dfe-header__navigation-item <%= 'dfe-header__navigation-item--current' if current_page?('/find-a-dfe-approved-buying-solution') %>">
         <a class="dfe-header__navigation-link" href="/find-a-dfe-approved-buying-solution">
           <%= t(".guidance") %>
           <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">

--- a/app/views/shared/_dfe_logo_and_menu.html.erb
+++ b/app/views/shared/_dfe_logo_and_menu.html.erb
@@ -6,7 +6,7 @@
     </a>
   </div>
   <div class="dfe-header__content" id="content-header">
-    <%= render "shared/dfe_search" if @show_search_in_header %>
+    <%= render "shared/dfe_narrow_search_box" if @show_search_in_header %>
     <div class="dfe-header__menu">
       <button class="dfe-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-expanded="false"><%= t(".menu") %></button>
     </div>

--- a/app/views/shared/_dfe_narrow_search_box.html.erb
+++ b/app/views/shared/_dfe_narrow_search_box.html.erb
@@ -3,23 +3,23 @@
     <svg class="dfe-icon dfe-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
       <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
     </svg>
-    <span class="govuk-visually-hidden"><%= t(".search") %></span>
+    <span class="govuk-visually-hidden"><%= t("shared.dfe_search.search") %></span>
   </button>
   <div class="dfe-header__search-wrap" id="wrap-search">
     <form class="dfe-header__search-form" id="search" action="/search" method="get" role="search">
-      <label class="govuk-visually-hidden" for="search-field"><%= t(".search_this_website") %></label>
+      <label class="govuk-visually-hidden" for="search-field"><%= t("shared.dfe_search.search_this_website") %></label>
       <input class="dfe-search__input" id="search-field" name="query" placeholder="Search" type="search" autocomplete="off" required value="<%= params[:query] %>">
       <button class="dfe-search__submit" type="submit">
         <svg class="dfe-icon dfe-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
           <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
         </svg>
-        <span class="govuk-visually-hidden"><%= t(".search") %></span>
+        <span class="govuk-visually-hidden"><%= t("shared.dfe_search.search") %></span>
       </button>
       <button class="dfe-search__close" id="close-search">
         <svg class="dfe-icon dfe-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
           <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
         </svg>
-        <span class="govuk-visually-hidden"><%= t(".close_search") %></span>
+        <span class="govuk-visually-hidden"><%= t("shared.dfe_search.close_search") %></span>
       </button>
     </form>
   </div>

--- a/app/views/shared/_dfe_narrow_search_box.html.erb
+++ b/app/views/shared/_dfe_narrow_search_box.html.erb
@@ -1,0 +1,26 @@
+<div class="dfe-header__search_narrow govuk-!-margin-top-8">
+  <button class="dfe-header__search-toggle" id="toggle-search" aria-controls="search" aria-label="Open search">
+    <svg class="dfe-icon dfe-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
+      <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+    </svg>
+    <span class="govuk-visually-hidden"><%= t(".search") %></span>
+  </button>
+  <div class="dfe-header__search-wrap" id="wrap-search">
+    <form class="dfe-header__search-form" id="search" action="/search" method="get" role="search">
+      <label class="govuk-visually-hidden" for="search-field"><%= t(".search_this_website") %></label>
+      <input class="dfe-search__input" id="search-field" name="query" placeholder="Search" type="search" autocomplete="off" required value="<%= params[:query] %>">
+      <button class="dfe-search__submit" type="submit">
+        <svg class="dfe-icon dfe-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
+          <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+        </svg>
+        <span class="govuk-visually-hidden"><%= t(".search") %></span>
+      </button>
+      <button class="dfe-search__close" id="close-search">
+        <svg class="dfe-icon dfe-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
+          <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        <span class="govuk-visually-hidden"><%= t(".close_search") %></span>
+      </button>
+    </form>
+  </div>
+</div>

--- a/app/views/shared/_dfe_search.html.erb
+++ b/app/views/shared/_dfe_search.html.erb
@@ -8,7 +8,8 @@
   <div class="dfe-header__search-wrap" id="wrap-search">
     <form class="dfe-header__search-form" id="search" action="/search" method="get" role="search">
       <label class="govuk-visually-hidden" for="search-field"><%= t(".search_this_website") %></label>
-      <input class="dfe-search__input" id="search-field" name="query" type="search" placeholder="Search" autocomplete="off" required value="<%= params[:query] %>">
+      <h5><%= t(".search") %></h5>
+      <input class="dfe-search__input" id="search-field" name="query" type="search" autocomplete="off" required value="<%= params[:query] %>">
       <button class="dfe-search__submit" type="submit">
         <svg class="dfe-icon dfe-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
           <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>

--- a/app/views/shared/_dfe_search.html.erb
+++ b/app/views/shared/_dfe_search.html.erb
@@ -1,4 +1,4 @@
-<div class="dfe-header__search">
+<div class="dfe-header__search govuk-!-margin-left-0">
   <button class="dfe-header__search-toggle" id="toggle-search" aria-controls="search" aria-label="Open search">
     <svg class="dfe-icon dfe-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
       <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>

--- a/app/views/shared/_dfe_sidebar.html.erb
+++ b/app/views/shared/_dfe_sidebar.html.erb
@@ -1,3 +1,3 @@
-<div class="sidebar govuk-grid-column-one-third govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+<div class="sidebar govuk-grid-column-one-third">
   <%= yield(:sidebar) %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,10 @@ en:
           category: Categories
           solution: Buying options
   search:
+    no_results:
+      cta: Visit Get Help Buying Home page
+      description: It looks like there are no results for your search keyword.
+      title: No search results
     title: Search Get Help Buying for Schools
   service:
     name: Get Help Buying for Schools

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
       procurement_support: Request help and support for your procurement
       terms_and_conditions: Terms and conditions
     dfe_homepage_header:
-      home_link: View list of all DfE approved buying options
+      view_all_buying_options: View list of all DfE approved buying options
     dfe_logo_and_menu:
       close_menu: Close menu
       guidance: Guidance

--- a/public/404.html
+++ b/public/404.html
@@ -169,13 +169,13 @@
             <a class="govuk-footer__link" href="/terms-and-conditions">Terms and conditions</a>
           </li>
         </ul>
-            <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+        <div>    <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
     <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
     </svg>
-
-        <span class="govuk-footer__licence-description">
+</div>
+        <div class="govuk-footer__licence-description">
           All content is available under the <a class="govuk-footer__link" rel="license" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated.
-        </span>
+        </div>
       </div>
       <div class="govuk-footer__meta-item">
         <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
@@ -183,6 +183,7 @@
     </div>
   </div>
 </footer>
+
 
 
 

--- a/public/500.html
+++ b/public/500.html
@@ -164,13 +164,13 @@
             <a class="govuk-footer__link" href="/terms-and-conditions">Terms and conditions</a>
           </li>
         </ul>
-            <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+        <div>    <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
     <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
     </svg>
-
-        <span class="govuk-footer__licence-description">
+</div>
+        <div class="govuk-footer__licence-description">
           All content is available under the <a class="govuk-footer__link" rel="license" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated.
-        </span>
+        </div>
       </div>
       <div class="govuk-footer__meta-item">
         <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
@@ -178,6 +178,7 @@
     </div>
   </div>
 </footer>
+
 
 
 

--- a/public/application.css
+++ b/public/application.css
@@ -9961,7 +9961,13 @@ footer {
 }
 
 .govuk-footer__list--inline {
+  max-width: 800px;
   display: flex;
   flex-wrap: wrap;
   gap: 15px;
+}
+
+.govuk-footer__licence-description {
+  margin-top: 10px;
+  max-width: 500px;
 }


### PR DESCRIPTION
This PR fixes a number of design and markup issues: 

- Remove extra H1 tags
- Add H1 tag on pages where it's missing
- Replace H2 with H1 for page titles
- Remove unused tags
- Fix alignment issues
- Fix current link highlighting in header nav
- Update layouts and styles to match latest designs
- Add empty state text for search results page

