### PR TITLE
Fixes: copy and back link

### DIFF
--- a/app/views/layouts/pages.html.erb
+++ b/app/views/layouts/pages.html.erb
@@ -1,5 +1,14 @@
 <%= render "shared/dfe_base" do %>
   <%= render "shared/dfe_header" %>
+  <div class="page-header">
+    <div class="dfe-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= govuk_back_link(href:  @page_back_link ) %>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <div class="page-with-sidebar">
     <div class="dfe-width-container">

--- a/app/views/layouts/pages.html.erb
+++ b/app/views/layouts/pages.html.erb
@@ -4,7 +4,7 @@
     <div class="dfe-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          <%= govuk_back_link(href:  @page_back_link ) %>
+          <%= govuk_back_link(href: @page_back_link ) %>
         </div>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,7 @@ en:
       apply: Apply
       filter: Filter
       section_title: Buying category
-      standfirst: All buying options are DfE approved and listed alphabetically.
+      standfirst: All buying options are DfE-approved and listed alphabetically.
       title: Buying options
   header_description: |
     A procurement hub to help you buy for your school, academy or trust and
@@ -56,7 +56,7 @@ en:
       procurement_support: Request help and support for your procurement
       terms_and_conditions: Terms and conditions
     dfe_homepage_header:
-      view_all_buying_options: View list of all DfE approved buying options
+      view_all_buying_options: View list of all DfE-approved buying options
     dfe_logo_and_menu:
       close_menu: Close menu
       guidance: Guidance


### PR DESCRIPTION
A couple of fixes based on the walkthrough conversation:

- Hyphenate "Dfe-approved"
- Restore back link on content pages

