### PR TITLE
Add ability to specify Contentful environment

### DIFF
--- a/app/models/contentful_client.rb
+++ b/app/models/contentful_client.rb
@@ -11,16 +11,18 @@ class ContentfulClient
     instance.client.entries(*args, **kwargs)
   end
 
-  def configure(space:, access_token:)
+  def configure(space:, access_token:, environment:)
     @space = space
     @access_token = access_token
+    @environment = environment
     @client = nil
   end
 
   def client
     @client ||= Contentful::Client.new(
       space: @space,
-      access_token: @access_token
+      access_token: @access_token,
+      environment: @environment
     )
   end
 end

--- a/config/initializers/contentful.rb
+++ b/config/initializers/contentful.rb
@@ -1,6 +1,7 @@
 Rails.configuration.to_prepare do
   ContentfulClient.configure(
     space: ENV.fetch("CONTENTFUL_SPACE_ID", "FAKE_SPACE_ID"),
-    access_token: ENV.fetch("CONTENTFUL_ACCESS_TOKEN", "FAKE_API_KEY")
+    access_token: ENV.fetch("CONTENTFUL_ACCESS_TOKEN", "FAKE_API_KEY"),
+    environment: ENV.fetch("CONTENTFUL_ENVIRONMENT", "master")
   )
 end


### PR DESCRIPTION
As we move towards launch, we need to be able to use separate environments in Contentful.

- Add configuration to specify a Contentful environment via an environment variable
- Use `master` environment by default (matching the default in Contentful)