### PR TITLE
Use environment variable to enable MS Clarity

### DIFF
--- a/app/views/shared/_dfe_base.html.erb
+++ b/app/views/shared/_dfe_base.html.erb
@@ -12,7 +12,7 @@
 
   <%= javascript_include_tag "application", defer: true %>
 
-  <% if Rails.env.production? %>
+  <% if ENV["MS_CLARITY_PROJECT_ID"] %>
     <%= render "shared/ms_clarity" %>
   <% end %>
 </head>

--- a/app/views/shared/_ms_clarity.html.erb
+++ b/app/views/shared/_ms_clarity.html.erb
@@ -3,5 +3,5 @@
         c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
         t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-    })(window, document, "clarity", "script", "qyat5oaxqd");
+    })(window, document, "clarity", "script", "<%= ENV['MS_CLARITY_PROJECT_ID'] %>");
 </script>


### PR DESCRIPTION
Use an environment variable to specify the MS Clarity project ID. This gives us finer control over configuring Clarity per environment.