### PR TITLE
FB-246 Redirect external links to track them in dfe-analytics

### DIFF
--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,14 +1,19 @@
 class RedirectsController < ApplicationController
-  def external
-    target_url = params[:url]
-    uri = URI.parse(target_url)
+  before_action :verify_external_url, only: :external
 
-    if uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-      redirect_to target_url, allow_other_host: true
-    else
-      redirect_to root_path
+  def external
+    redirect_to @verified_url, allow_other_host: true
+  end
+
+private
+
+  def verify_external_url
+    @verified_url = REDIRECT_VERIFIER.verify(params[:token])
+    uri = URI.parse(@verified_url)
+    unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+      redirect_to(root_path) and return
     end
-  rescue URI::InvalidURIError
-    redirect_to root_path
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, URI::InvalidURIError
+    redirect_to(root_path) and return
   end
 end

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,0 +1,14 @@
+class RedirectsController < ApplicationController
+  def external
+    target_url = params[:url]
+    uri = URI.parse(target_url)
+
+    if uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+      redirect_to target_url, allow_other_host: true
+    else
+      redirect_to root_path
+    end
+  rescue URI::InvalidURIError
+    redirect_to root_path
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,16 +5,51 @@ module ApplicationHelper
 
   def safe_url(url)
     return "#" unless url.is_a?(String)
+    return url if internal_path?(url)
+    return "#" unless valid_uri?(url)
+    return url if same_host?(url)
 
-    uri = URI.parse(url)
-    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS) ? url : "#"
+    # We're using this redirector so that we can track external link clicks
+    # in dfe-analytics automatically without having to write custom JavaScript.
+    # Even with custom JS, we'd still need to redirect the user after tracking
+    # the event. So this is a cleaner approach with less code.
+    "/external-redirect?url=#{CGI.escape(url)}"
   rescue URI::InvalidURIError
     "#"
+  end
+
+  def external_link_attributes(url)
+    return {} unless url.is_a?(String)
+
+    uri = URI.parse(url)
+    if (uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)) && uri.host != request.host
+      { target: "_blank", rel: "noopener noreferrer" }
+    else
+      {}
+    end
+  rescue URI::InvalidURIError
+    {}
   end
 
   def format_date(date_string)
     return "" if date_string.blank?
 
     I18n.l(Date.parse(date_string), format: :standard)
+  end
+
+private
+
+  def internal_path?(url)
+    url.start_with?("/")
+  end
+
+  def valid_uri?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+  end
+
+  def same_host?(url)
+    uri = URI.parse(url)
+    uri.host == request.host
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,8 @@ module ApplicationHelper
     # in dfe-analytics automatically without having to write custom JavaScript.
     # Even with custom JS, we'd still need to redirect the user after tracking
     # the event. So this is a cleaner approach with less code.
-    "/external-redirect?url=#{CGI.escape(url)}"
+    token = REDIRECT_VERIFIER.generate(url)
+    external_redirect_path(token: token)
   rescue URI::InvalidURIError
     "#"
   end

--- a/app/views/shared/_related_content.html.erb
+++ b/app/views/shared/_related_content.html.erb
@@ -3,7 +3,7 @@
 
   <% related_content.each do |link| %>
     <p>
-      <%= govuk_link_to link.link_text, link.url, class: "govuk-!-font-weight-bold" %>
+      <%= govuk_link_to link.link_text, safe_url(link.url), class: "govuk-!-font-weight-bold", **external_link_attributes(link.url) %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/solutions/show.html.erb
+++ b/app/views/solutions/show.html.erb
@@ -1,6 +1,6 @@
 <%= render_markdown_to_html(@solution.summary) %>
 
-<%= link_to h(solution_cta(@solution)), safe_url(@solution.url), class: "govuk-button" %>
+<%= link_to h(solution_cta(@solution)), safe_url(@solution.url), class: "govuk-button", **external_link_attributes(@solution.url) %>
 
 <% content_for :sidebar do %>
   <%= render partial: "shared/related_content", locals: { related_content: @solution.related_content } %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,28 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "3b23d1aca4af19136ed8cf539538d64766ee5bfe7321f30b119edf9cfcd56c45",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/redirects_controller.rb",
+      "line": 8,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(params[:url], :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RedirectsController",
+        "method": "external"
+      },
+      "user_input": "params[:url]",
+      "confidence": "Weak",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
+    }
+  ],
+  "brakeman_version": "7.0.2"
+}

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,20 +3,20 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "3b23d1aca4af19136ed8cf539538d64766ee5bfe7321f30b119edf9cfcd56c45",
+      "fingerprint": "2c70d82f97d075d5852459a8604796316de688f53a421b0a4f05e7e7f7f433d3",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/redirects_controller.rb",
-      "line": 8,
+      "line": 5,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(params[:url], :allow_other_host => true)",
+      "code": "redirect_to(REDIRECT_VERIFIER.verify(params[:token]), :allow_other_host => true)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "RedirectsController",
         "method": "external"
       },
-      "user_input": "params[:url]",
+      "user_input": "params[:token]",
       "confidence": "Weak",
       "cwe_id": [
         601

--- a/config/initializers/redirect_verifier.rb
+++ b/config/initializers/redirect_verifier.rb
@@ -1,0 +1,3 @@
+REDIRECT_VERIFIER = ActiveSupport::MessageVerifier.new(
+  Rails.application.secret_key_base, digest: "SHA256"
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :categories, only: %i[show index], param: :slug
   resources :solutions, only: %i[show index], param: :slug
   get "/search", to: "search#index"
+  get "/external-redirect", to: "redirects#external"
 
   # Keep this route at the bottom so that it doesn't override the other routes
   get "/:slug", to: "pages#show", as: :page

--- a/spec/controllers/redirects_controller_spec.rb
+++ b/spec/controllers/redirects_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe RedirectsController, type: :controller do
+  describe "GET #external" do
+    def perform_request_for(url)
+      token = REDIRECT_VERIFIER.generate(url)
+      get :external, params: { token: token }
+    end
+
+    it "redirects to the verified URL" do
+      url = "https://foo.example.com/bar"
+      perform_request_for(url)
+      expect(response).to redirect_to(url)
+    end
+
+    it "escapes the URL properly" do
+      url = "https://external.com/path?q=1&t=2"
+      perform_request_for(url)
+      expect(response).to redirect_to(url)
+    end
+
+    it "handles URLs with existing query params and special chars" do
+      url = "https://external.com/path?q=hello world&t=test+this"
+      perform_request_for(url)
+      expect(response).to redirect_to(url)
+    end
+
+    it "rejects an invalid token" do
+      get :external, params: { token: "bogus" }
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/features/solutions_spec.rb
+++ b/spec/features/solutions_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Solutions pages", :vcr, type: :feature do
       visit solution_path("it-hardware")
       expect(page).to have_link(
         "Visit the IT Hardware website",
-        href: "/external-redirect?url=#{CGI.escape('https://www.procurementservices.co.uk/our-solutions/frameworks/technology/it-hardware')}",
+        href: "/external-redirect?token=BAhJIlpodHRwczovL3d3dy5wcm9jdXJlbWVudHNlcnZpY2VzLmNvLnVrL291ci1zb2x1dGlvbnMvZnJhbWV3b3Jrcy90ZWNobm9sb2d5L2l0LWhhcmR3YXJlBjoGRVQ%3D--722dd2ff79eeec7c2bd089af5855aef1c4295a21b99ece32d7d5f639c17ff975",
         class: "govuk-button"
       )
     end
@@ -56,7 +56,7 @@ RSpec.describe "Solutions pages", :vcr, type: :feature do
       visit solution_path("ict-procurement")
       expect(page).to have_link(
         "Go to site",
-        href: "/external-redirect?url=#{CGI.escape('https://www.everythingict.org/')}",
+        href: "/external-redirect?token=BAhJIiNodHRwczovL3d3dy5ldmVyeXRoaW5naWN0Lm9yZy8GOgZFVA%3D%3D--09ac77a9d080f743bdb863a8a05dd18c27c3fa7edfbf34599385b05c024df5c7",
         class: "govuk-button"
       )
     end

--- a/spec/features/solutions_spec.rb
+++ b/spec/features/solutions_spec.rb
@@ -45,16 +45,20 @@ RSpec.describe "Solutions pages", :vcr, type: :feature do
   context "when displaying call to action button" do
     it "displays the default CTA text when no custom CTA is provided" do
       visit solution_path("it-hardware")
-      expect(page).to have_link("Visit the IT Hardware website",
-                                href: "https://www.procurementservices.co.uk/our-solutions/frameworks/technology/it-hardware",
-                                class: "govuk-button")
+      expect(page).to have_link(
+        "Visit the IT Hardware website",
+        href: "/external-redirect?url=#{CGI.escape('https://www.procurementservices.co.uk/our-solutions/frameworks/technology/it-hardware')}",
+        class: "govuk-button"
+      )
     end
 
     it "displays the custom CTA text when provided" do
       visit solution_path("ict-procurement")
-      expect(page).to have_link("Go to site",
-                                href: "https://www.everythingict.org/",
-                                class: "govuk-button")
+      expect(page).to have_link(
+        "Go to site",
+        href: "/external-redirect?url=#{CGI.escape('https://www.everythingict.org/')}",
+        class: "govuk-button"
+      )
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#safe_url" do
+    before do
+      allow(helper.request).to receive(:host).and_return("example.com")
+    end
+
+    it "returns '#' for nil" do
+      expect(helper.safe_url(nil)).to eq("#")
+    end
+
+    it "returns '#' for non-string input" do
+      expect(helper.safe_url(123)).to eq("#")
+    end
+
+    it "returns '#' for invalid URLs" do
+      expect(helper.safe_url("not a url")).to eq("#")
+    end
+
+    context "with internal URLs" do
+      it "returns the URL unchanged if on same host" do
+        expect(helper.safe_url("https://example.com/path")).to eq("https://example.com/path")
+      end
+
+      it "handles paths without host" do
+        expect(helper.safe_url("/some/path")).to eq("/some/path")
+      end
+    end
+
+    context "with external URLs" do
+      it "returns redirect URL for different host" do
+        expect(helper.safe_url("https://external.com/path"))
+          .to eq("/external-redirect?url=https%3A%2F%2Fexternal.com%2Fpath")
+      end
+
+      it "properly escapes URLs in redirect path" do
+        expect(helper.safe_url("https://external.com/path?q=1&t=2"))
+          .to eq("/external-redirect?url=https%3A%2F%2Fexternal.com%2Fpath%3Fq%3D1%26t%3D2")
+      end
+
+      it "handles URLs with existing query params and special chars" do
+        expect(helper.safe_url("https://external.com/path?q=hello world&t=test+this"))
+          .to eq("/external-redirect?url=https%3A%2F%2Fexternal.com%2Fpath%3Fq%3Dhello+world%26t%3Dtest%2Bthis")
+      end
+    end
+  end
+
+  describe "#external_link_attributes" do
+    before do
+      allow(helper.request).to receive(:host).and_return("example.com")
+    end
+
+    it "returns empty hash for nil" do
+      expect(helper.external_link_attributes(nil)).to eq({})
+    end
+
+    it "returns empty hash for non-string input" do
+      expect(helper.external_link_attributes(123)).to eq({})
+    end
+
+    it "returns empty hash for invalid URLs" do
+      expect(helper.external_link_attributes("not a url")).to eq({})
+    end
+
+    context "with internal URLs" do
+      it "returns empty hash if on same host" do
+        expect(helper.external_link_attributes("https://example.com/path")).to eq({})
+      end
+
+      it "returns empty hash for paths without host" do
+        expect(helper.external_link_attributes("/some/path")).to eq({})
+      end
+    end
+
+    context "with external URLs" do
+      it "returns target/rel hash for different host" do
+        expect(helper.external_link_attributes("https://external.com/path"))
+          .to eq({ target: "_blank", rel: "noopener noreferrer" })
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -29,19 +29,9 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context "with external URLs" do
-      it "returns redirect URL for different host" do
+      it "returns redirect URL token for different host" do
         expect(helper.safe_url("https://external.com/path"))
-          .to eq("/external-redirect?url=https%3A%2F%2Fexternal.com%2Fpath")
-      end
-
-      it "properly escapes URLs in redirect path" do
-        expect(helper.safe_url("https://external.com/path?q=1&t=2"))
-          .to eq("/external-redirect?url=https%3A%2F%2Fexternal.com%2Fpath%3Fq%3D1%26t%3D2")
-      end
-
-      it "handles URLs with existing query params and special chars" do
-        expect(helper.safe_url("https://external.com/path?q=hello world&t=test+this"))
-          .to eq("/external-redirect?url=https%3A%2F%2Fexternal.com%2Fpath%3Fq%3Dhello+world%26t%3Dtest%2Bthis")
+          .to eq("/external-redirect?token=BAhJIh5odHRwczovL2V4dGVybmFsLmNvbS9wYXRoBjoGRVQ%3D--0ccbfe4b58df97e2ec4821d6a7eb302998ac4231ee0283bceb95d50db9087303")
       end
     end
   end


### PR DESCRIPTION
JIRA ticket - https://dfedigital.atlassian.net/browse/FB-246

The` dfe-analytics` gem automatically tracks all pageviews within our website. However, if a user clicks on a link to an external site (e.g. a framework website or gov uk support page), those clicks are not automatically tracked.

This PR adds a way to track external link clicks - 

- Add redirection for external links so they can be automatically tracked as an event in `dfe-analytics`
- Automatically add `rel` and `target` attributes to external links
- Add specs

Another option I considered is to use frontend JavaScript to track external link clicks. This would also require creating a new backend endpoint to track clicks as custom events. And we'd still need to redirect the user after tracking the event. 

So I chose this simpler approach which doesn't require any JS code.
