### PR TITLE
[FB-247] Add middleware to set HTTP_X_REAL_IP

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative "boot"
+require_relative "../lib/real_ip"
 
 require "rails"
 # Pick the frameworks you want:
@@ -22,6 +23,8 @@ module FindABuyingSolution
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
+
+    config.middleware.use RealIp
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/real_ip.rb
+++ b/lib/real_ip.rb
@@ -1,0 +1,12 @@
+class RealIp
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env["HTTP_X_FORWARDED_FOR"].present?
+      env["HTTP_X_REAL_IP"] = env["HTTP_X_FORWARDED_FOR"].split(",")&.first
+    end
+    @app.call(env)
+  end
+end

--- a/spec/lib/real_ip_spec.rb
+++ b/spec/lib/real_ip_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe RealIp do
+  subject(:middleware) { described_class.new(dummy_app) }
+
+  let(:dummy_app) { ->(_env) { [200, {}, %w[OK]] } }
+
+  describe "#call" do
+    it "sets HTTP_X_REAL_IP to the first IP in HTTP_X_FORWARDED_FOR" do
+      env = { "HTTP_X_FORWARDED_FOR" => "1.2.3.4, 5.6.7.8" }
+      middleware.call(env)
+      expect(env["HTTP_X_REAL_IP"]).to eq "1.2.3.4"
+    end
+
+    it "does not set HTTP_X_REAL_IP when header is missing or blank" do
+      [{}, { "HTTP_X_FORWARDED_FOR" => "" }].each do |e|
+        middleware.call(e)
+        expect(e).not_to have_key("HTTP_X_REAL_IP")
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA ticket - https://dfedigital.atlassian.net/browse/FB-247

Add middleware to set `HTTP_X_REAL_IP` for anonymised user journey tracking in dfe analytics

The `dfe-analytics` gem relies on the `X-REAL-IP` header to create an `anonymised_user_agent_and_ip` attribute in tracked events. This is useful for tracking user journeys without PII. 

However, we don't have the `X-REAL-IP` header on Heroku.

This PR defines a new middleware to set `X-REAL-IP` to the first value in `X-Forwarded-For`.

<img width="1331" alt="Screenshot 2025-04-22 at 6 51 19 pm" src="https://github.com/user-attachments/assets/831574d8-ce82-4aa4-994a-dcd325ad3421" />
