### PR TITLE
FB-234-Update the homepage to remove navigation and the guidance page

### DIFF
--- a/app/views/shared/_dfe_logo_and_menu.html.erb
+++ b/app/views/shared/_dfe_logo_and_menu.html.erb
@@ -16,35 +16,3 @@
 <div class="dfe-width-container dfe-header__service-name">
   <a href="/" class="dfe-header__link--service"><%= t("header_title") %></a>
 </div>
-
-<nav class="dfe-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
-  <div class="dfe-width-container">
-    <p class="dfe-header__navigation-title">
-      <span id="label-navigation"><%= t(".menu") %></span>
-      <button class="dfe-header__navigation-close" id="close-menu">
-        <svg class="dfe-icon dfe-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
-          <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-        </svg>
-        <span class="govuk-visually-hidden"><%= t(".close_menu") %></span>
-      </button>
-    </p>
-    <ul class="dfe-header__navigation-list">
-      <li class="dfe-header__navigation-item <%= 'dfe-header__navigation-item--current' if current_page?('/') %>">
-        <a class="dfe-header__navigation-link" href="/">
-          <%= t(".home") %>
-          <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-          </svg>
-        </a>
-      </li>
-      <li class="dfe-header__navigation-item <%= 'dfe-header__navigation-item--current' if current_page?('/find-a-dfe-approved-buying-solution') %>">
-        <a class="dfe-header__navigation-link" href="/find-a-dfe-approved-buying-solution">
-          <%= t(".guidance") %>
-          <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-          </svg>
-        </a>
-      </li>
-    </ul>
-  </div>
-</nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,8 @@ en:
       terms_and_conditions: Terms and conditions
     dfe_homepage_header:
       view_all_buying_options: Browse a list of all DfE-approved buying options
+    dfe_logo_and_menu:
+      menu: Menu
     dfe_search:
       close_search: Close search
       search: Search

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,7 +59,6 @@ en:
       view_all_buying_options: Browse a list of all DfE-approved buying options
     dfe_logo_and_menu:
       close_menu: Close menu
-      guidance: Guidance
       home: Home
       menu: Menu
     dfe_search:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,10 +57,6 @@ en:
       terms_and_conditions: Terms and conditions
     dfe_homepage_header:
       view_all_buying_options: Browse a list of all DfE-approved buying options
-    dfe_logo_and_menu:
-      close_menu: Close menu
-      home: Home
-      menu: Menu
     dfe_search:
       close_search: Close search
       search: Search

--- a/public/404.html
+++ b/public/404.html
@@ -69,47 +69,6 @@
       <a href="/" class="dfe-header__link--service">Get Help Buying for Schools</a>
     </div>
 
-    <nav class="dfe-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation"
-      aria-labelledby="label-navigation">
-      <div class="dfe-width-container">
-        <p class="dfe-header__navigation-title">
-          <span id="label-navigation">Menu</span>
-          <button class="dfe-header__navigation-close" id="close-menu">
-            <svg class="dfe-icon dfe-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-              aria-hidden="true" focusable="false" width="27" height="27">
-              <path
-                d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z">
-              </path>
-            </svg>
-            <span class="govuk-visually-hidden">Close menu</span>
-          </button>
-        </p>
-        <ul class="dfe-header__navigation-list">
-          <li class="dfe-header__navigation-item dfe-header__navigation-item--current">
-            <a class="dfe-header__navigation-link" href="/">
-              Home
-              <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                aria-hidden="true" width="34" height="34">
-                <path
-                  d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z">
-                </path>
-              </svg>
-            </a>
-          </li>
-          <li class="dfe-header__navigation-item ">
-            <a class="dfe-header__navigation-link" href="/find-a-dfe-approved-buying-solution">
-              Guidance
-              <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                aria-hidden="true" width="34" height="34">
-                <path
-                  d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z">
-                </path>
-              </svg>
-            </a>
-          </li>
-        </ul>
-      </div>
-    </nav>
     <div class="beta-banner-container manual-promo-strip govuk-!-margin-top-4">
       <div class="beta-banner dfe-width-container">
         <div class="govuk-grid-row">

--- a/public/500.html
+++ b/public/500.html
@@ -70,47 +70,6 @@
       <a href="/" class="dfe-header__link--service">Get Help Buying for Schools</a>
     </div>
 
-    <nav class="dfe-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation"
-      aria-labelledby="label-navigation">
-      <div class="dfe-width-container">
-        <p class="dfe-header__navigation-title">
-          <span id="label-navigation">Menu</span>
-          <button class="dfe-header__navigation-close" id="close-menu">
-            <svg class="dfe-icon dfe-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-              aria-hidden="true" focusable="false" width="27" height="27">
-              <path
-                d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z">
-              </path>
-            </svg>
-            <span class="govuk-visually-hidden">Close menu</span>
-          </button>
-        </p>
-        <ul class="dfe-header__navigation-list">
-          <li class="dfe-header__navigation-item dfe-header__navigation-item--current">
-            <a class="dfe-header__navigation-link" href="/">
-              Home
-              <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                aria-hidden="true" width="34" height="34">
-                <path
-                  d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z">
-                </path>
-              </svg>
-            </a>
-          </li>
-          <li class="dfe-header__navigation-item ">
-            <a class="dfe-header__navigation-link" href="/find-a-dfe-approved-buying-solution">
-              Guidance
-              <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                aria-hidden="true" width="34" height="34">
-                <path
-                  d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z">
-                </path>
-              </svg>
-            </a>
-          </li>
-        </ul>
-      </div>
-    </nav>
     <div class="beta-banner-container manual-promo-strip govuk-!-margin-top-4">
       <div class="beta-banner dfe-width-container">
         <div class="govuk-grid-row">


### PR DESCRIPTION
- Removed navigation bar
- Home and Guidance no longer appear on the Homepage

- After change screenshot:

![Screenshot 2025-04-24 at 16 53 41](https://github.com/user-attachments/assets/9bf8c172-9ec7-4539-9b25-30529407c69c)

