### PR TITLE
FB-246 Track external link clicks with dfe-analytics

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,11 @@
+import { Application } from "@hotwired/stimulus"
+import ExternalLinkTrackingController from "../../javascript/controllers/external_link_tracking_controller"
+
 import 'dfe-frontend/packages/dfefrontend';
 
 import * as govukFrontend from 'govuk-frontend';
 govukFrontend.initAll();
+
+const application = Application.start();
+window.Stimulus = application;
+Stimulus.register("external-link-tracking", ExternalLinkTrackingController);

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,35 @@
+class EventsController < ApplicationController
+  EVENT_ALLOWLIST = {
+    external_link_clicked: %i[text href],
+  }.freeze
+
+  def create
+    type = event_params[:type]&.to_sym
+    return bad_request unless EVENT_ALLOWLIST.key?(type)
+
+    data = event_params[:data].to_h.slice(*EVENT_ALLOWLIST[type])
+    send_dfe_analytics_event(type, data)
+
+    head :no_content
+  end
+
+private
+
+  def event_params
+    params.require(:event).permit(:type, data: {})
+  end
+
+  def bad_request
+    head(:bad_request)
+  end
+
+  def send_dfe_analytics_event(type, data)
+    event = DfE::Analytics::Event.new
+      .with_type(type)
+      .with_request_details(request)
+      .with_response_details(response)
+      .with_data(data:)
+
+    DfE::Analytics::SendEvents.do([event])
+  end
+end

--- a/app/javascript/controllers/external_link_tracking_controller.js
+++ b/app/javascript/controllers/external_link_tracking_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    document.querySelectorAll('a').forEach(link => {
+      if (this.isExternalLink(link.href)) {
+        link.addEventListener('click', this.trackClick.bind(this))
+      }
+    })
+  }
+
+  isExternalLink(href) {
+    try {
+      const url = new URL(href)
+      return url.hostname !== window.location.hostname
+    } catch {
+      return false
+    }
+  }
+
+  async trackClick(event) {
+    event.preventDefault();
+    const link = event.currentTarget
+    const href = link.href
+    const text = link.textContent.trim()
+
+    try {
+      await fetch('/events', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        },
+        body: JSON.stringify({
+          event: {
+            type: 'external_link_clicked',
+            data: {
+              href,
+              text,
+            }
+          }
+        })
+      })
+    } finally {
+      window.open(href, '_blank', 'noopener,noreferrer');
+    }
+  }
+}

--- a/app/views/shared/_dfe_base.html.erb
+++ b/app/views/shared/_dfe_base.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 </head>
 
-<body class="govuk-template__body">
+<body class="govuk-template__body" data-controller="external-link-tracking">
   <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
   <%= yield %>
 </body>

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,0 +1,2 @@
+shared:
+  - external_link_clicked

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :categories, only: %i[show index], param: :slug
   resources :solutions, only: %i[show index], param: :slug
   get "/search", to: "search#index"
+  post "/events", to: "events#create"
 
   # Keep this route at the bottom so that it doesn't override the other routes
   get "/:slug", to: "pages#show", as: :page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "app",
   "dependencies": {
+    "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/turbo-rails": "^7.3.0",
     "@ministryofjustice/frontend": "^4.0.1",
     "dfe-frontend": "^2.0.1",
     "govuk-frontend": "^5.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,6 +180,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hotwired/stimulus@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@hotwired/stimulus@npm:3.2.2"
+  checksum: 10c0/3793919e353d28424f57d07e6b634bf6e8821c227acfa2a608aaa8bdfe7e80479acef12705168ca866f3c231399f4a939fb0cd089aaae04c406b3d885a3b35ea
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo-rails@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "@hotwired/turbo-rails@npm:7.3.0"
+  dependencies:
+    "@hotwired/turbo": "npm:^7.3.0"
+    "@rails/actioncable": "npm:^7.0"
+  checksum: 10c0/1b2a5bc8767f0366c91a80a6bac178b8b02ca607add5b14b637f128d9ff08629bf3761931cc892acd46175782649ebdffa76dd45fc7e23f44bff8c06ca452d0b
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "@hotwired/turbo@npm:7.3.0"
+  checksum: 10c0/be7d273808d64e06682f413ea007b555ecc0077cfd846754fe3b1bca06ca1b9473184d95528f7de0f3002bbc7895d58a067845ba363c549229c3bc5870c981e2
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -387,6 +411,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rails/actioncable@npm:^7.0":
+  version: 7.2.201
+  resolution: "@rails/actioncable@npm:7.2.201"
+  checksum: 10c0/65463467f1473f810273432b85a272798c8fbe6c8a200be4f8ecbced152deac7bc3f159cd3db7ce7ab05b34cce25582d384cf51f0028c3c2baf303186e0f24f5
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^3.0.0":
   version: 3.0.0
   resolution: "abbrev@npm:3.0.0"
@@ -435,6 +466,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:."
   dependencies:
+    "@hotwired/stimulus": "npm:^3.2.2"
+    "@hotwired/turbo-rails": "npm:^7.3.0"
     "@ministryofjustice/frontend": "npm:^4.0.1"
     dfe-frontend: "npm:^2.0.1"
     esbuild: "npm:^0.25.0"


### PR DESCRIPTION
JIRA ticket - https://dfedigital.atlassian.net/browse/FB-246

The` dfe-analytics` gem automatically tracks all pageviews within our website. However, if a user clicks on a link to an external site (e.g. a framework website or gov uk support page), those clicks are not automatically tracked.

This PR adds a way to track external link clicks - 

- Add Stimulus controller to listen for link clicks and track a custom event called `external_link_clicked`
- Add Rails controller to track events with `dfe-analytics`
- Open external links in new tab
- Add `rel` attributes to external links

Screenshot below shows a tracked event in BigQuery:

<img width="1516" alt="Screenshot 2025-04-29 at 9 50 08 pm" src="https://github.com/user-attachments/assets/2937828d-2475-4c23-92ed-630e7c23ff23" />
