### PR TITLE
FB-230 Add link to Usability Survey on Solution show page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,18 @@ module ApplicationHelper
     "#"
   end
 
+  def usability_survey_url(url)
+    base_url = "https://get-help-buying-for-schools.service.gov.uk/usability_surveys/new"
+    safe_url = safe_url(url)
+    return_url = safe_url == "#" ? request.original_url : safe_url
+
+    params = {
+      service: "find_a_buying_solution",
+      return_url: UrlVerifier.generate(return_url),
+    }
+    "#{base_url}?#{params.to_query}"
+  end
+
   def format_date(date_string)
     return "" if date_string.blank?
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
   end
 
   def usability_survey_url(url)
-    base_url = "https://get-help-buying-for-schools.service.gov.uk/usability_surveys/new"
+    base_url = "https://www.get-help-buying-for-schools.service.gov.uk/usability_surveys/new"
     safe_url = safe_url(url)
     return_url = safe_url == "#" ? request.original_url : safe_url
 

--- a/app/javascript/controllers/external_link_tracking_controller.js
+++ b/app/javascript/controllers/external_link_tracking_controller.js
@@ -23,6 +23,7 @@ export default class extends Controller {
     const link = event.currentTarget
     const href = link.href
     const text = link.textContent.trim()
+    const surveyUrl = link.dataset.surveyUrl
 
     try {
       await fetch('/events', {
@@ -42,7 +43,7 @@ export default class extends Controller {
         })
       })
     } finally {
-      window.open(href, '_blank', 'noopener,noreferrer');
+      window.open(surveyUrl || href, '_blank', 'noopener,noreferrer');
     }
   }
 }

--- a/app/services/url_verifier.rb
+++ b/app/services/url_verifier.rb
@@ -1,0 +1,15 @@
+class UrlVerifier
+  def self.verifier
+    @verifier ||= ActiveSupport::MessageVerifier.new(ENV.fetch("URL_VERIFIER_SECRET", "FAKE_SECRET"))
+  end
+
+  def self.verify_url(signed_url)
+    verifier.verify(signed_url)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    nil
+  end
+
+  def self.generate(url)
+    verifier.generate(url)
+  end
+end

--- a/app/views/solutions/show.html.erb
+++ b/app/views/solutions/show.html.erb
@@ -4,7 +4,7 @@
   <%= render_markdown_to_html(@solution.suffix.description) %>
 <% end %>
 
-<%= link_to h(solution_cta(@solution)), safe_url(@solution.url), class: "govuk-button" %>
+<%= link_to h(solution_cta(@solution)), safe_url(@solution.url), class: "govuk-button", data: { survey_url: usability_survey_url(@solution.url) } %>
 
 <% content_for :sidebar do %>
   <%= render partial: "shared/related_content", locals: { related_content: @solution.related_content } %>

--- a/spec/features/solutions_spec.rb
+++ b/spec/features/solutions_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe "Solutions pages", :vcr, type: :feature do
       visit solution_path("it-hardware")
       link = find("a.govuk-button[data-survey-url]", match: :first)
       survey_url = link["data-survey-url"]
+      uri = URI.parse(survey_url)
 
+      expect(uri.host).to eq("www.get-help-buying-for-schools.service.gov.uk")
       expect(survey_url).to include("service=find_a_buying_solution")
       expect(survey_url).to match(/return_url=[^&]+/)
     end

--- a/spec/features/solutions_spec.rb
+++ b/spec/features/solutions_spec.rb
@@ -56,5 +56,14 @@ RSpec.describe "Solutions pages", :vcr, type: :feature do
                                 href: "https://www.everythingict.org/",
                                 class: "govuk-button")
     end
+
+    it "includes the usability survey URL with service and return_url params" do
+      visit solution_path("it-hardware")
+      link = find("a.govuk-button[data-survey-url]", match: :first)
+      survey_url = link["data-survey-url"]
+
+      expect(survey_url).to include("service=find_a_buying_solution")
+      expect(survey_url).to match(/return_url=[^&]+/)
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/Solutions_pages/when_displaying_call_to_action_button/includes_the_usability_survey_URL_as_a_data_attribute.yml
+++ b/spec/fixtures/vcr_cassettes/Solutions_pages/when_displaying_call_to_action_button/includes_the_usability_survey_URL_as_a_data_attribute.yml
@@ -1,0 +1,181 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cdn.contentful.com/spaces/FAKE_SPACE_ID/environments/master/entries?content_type=solution&fields.slug=it-hardware&include=1&select=fields.title,fields.description,fields.expiry,fields.related_content,fields.summary,fields.slug,fields.suffix,fields.provider_name,fields.call_to_action,fields.url,sys
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful.rb/2.17.1; platform ruby/3.4.1; os macOS/24;
+      Authorization:
+      - Bearer FAKE_API_KEY
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
+      Host:
+      - cdn.contentful.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1108'
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Cf-Space-Id:
+      - FAKE_SPACE_ID
+      Cf-Environment-Id:
+      - master
+      Cf-Environment-Uuid:
+      - 1bae0c6c-9bf9-4c44-9420-7099ae5e9248
+      Cf-Organization-Id:
+      - 3za11RVJBwLIPn20QJ67Gq
+      X-Contentful-Route:
+      - "/spaces/:space/environments/:environment/entries"
+      Etag:
+      - W/"5579659512081360399"
+      X-Contentful-Upstream-Request-Time:
+      - '0.106'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - Contentful
+      X-Contentful-Region:
+      - us-east-1
+      Contentful-Api:
+      - cda
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Resource-Resolution
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '86400'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,OPTIONS
+      Content-Encoding:
+      - gzip
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Wed, 07 May 2025 08:52:52 GMT
+      X-Served-By:
+      - cache-ewr-kewr1740089-EWR, cache-lhr-egll1980095-LHR
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1746607972.485067,VS0,VE193
+      X-Cache:
+      - MISS
+      X-Contentful-Request-Id:
+      - 71fd9f8e-8a66-4fb9-99ba-a89edf7be997
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA9VWbW/bNhD+vl9BKF8tWZIdx9G3NFvRANnQNc6CpSkCmjpZTChS4ItfEuS/70jJtdumaAY0GAYYsEXfnXh3zz3PPUZmY6LiMbKbFqIiOtGabqKnQWSVpSIqskFk7nkbFekgErzhFo9S/M0tNOj38TGqOIiyC8Gt8DHOZuQd1eWKaogGUQmGad5arqSPTyonBNFULoCoiqBt3dsSLplwJZcLImE1IBoqp+fc1FAOCJUlHjRUuooy6zSUCTmzhAqjej8waNBSrgek5KZVhorgRY1RjFMLJTGgl5yh4e5NxrWt0hgILRvKpQVJJfP3hnXL9QavnKf5YZxO41E2S9MifJI0Ta/RRoPwgW+Z8o5YG6zHl/U85/IeDQV+zboK/yYthsUKlhg7e/Nw1Z7+AWcP768+/GrrP+/W5+Jd9PT0CevumoaGGxwckKuaWsItlqwCbcjBwY2c1dyQStMGVkrfE3wwrUATTEKRSjlNzpU1IbNWqyXHRhD6/yh/ciNvJGb9BiRUHJPw+caEqaYFyy1fAqbEmYeKT8+0gB0W+L8s8V8lDYE1Ysl4QywGlI5Rf+6DADUbf+gMkBW3NZYQIIQJyNwCotKqIbb2L1IM8dZgf3cAskAbH0zp0reDUUnmaCooQ5gtOUUIamAIKxwChGAIrjGa3uXgb4MwMMItsMXcxts58Ieuqvjaj+W/QtPkZJPb5vrhMvuQO3bK5PzCZm8RTYOoR4C+lYgXfN/7vawu+rHAFzuNMx/V1ramGA5Xq1Wyl/52fBKmEnc/RITFRgkXCj78DEQztMBqqYRabIb7aeEt+mxMi3V6SXYXwbCfFTVhps5Gk7vsToecwgRNW51drnV5Tc+Xf2f0+PeTeZ6hS89n22ljGvyknuCM9gM9irPJLM+LfFKMxslRPvUD7dryK7NxnOezLCvGeZEeJ+PDsTcDueRaSY+JvTTCfRpqLOjdBZ4jgJ1zaI2bi8ByfyGUAkvmY08tS949ZcjBPcF0FPJjVJx2fBTM+zptOxUqJxSjgapBxpcXHd10nAiBybuqeTZrwFIsCQ0SQRee8pGa8DoMWhueXqet3yHGF/U1z2bZqMixZ5NkenT8fF9H8TNmr9zX6Rdt/Rld/VqAnmvuYE+ivQ7dWlj7MUD9kAvjqRDbaVAeNFnVgETmNp5Yz2Z+Hr7hg4Va+uFfOF56oRx21nGlkAxYrZQwsQ2BY6vibeB4DmgA8Ua52Fiq7ZAzGyMtokXTOhyYHfthCv8d7L7DoC+A3ZYnRtNilCVH2eHzsEOz6Sw9LtJxMTpMjieBdV4ZdpN92OU/A3a9Pv0IbSjVgWXefl5SesdvtkIU3p2AdFtd2HQKvwh0wi+4x1sn2V6XEfqwpCjK+wKtYeFwJfOK5P28mAvuFbpF9LEa2D3q8xz1HwPQ1osiPu92qK1Kel/vQRe4G5QE8dl0i9Ruw/Ck+fT0yz95e1KgQAsAAA==
+  recorded_at: Wed, 07 May 2025 08:52:52 GMT
+- request:
+    method: get
+    uri: https://cdn.contentful.com/spaces/FAKE_SPACE_ID/environments/master/entries?content_type=category&fields.slug
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful.rb/2.17.1; platform ruby/3.4.1; os macOS/24;
+      Authorization:
+      - Bearer FAKE_API_KEY
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
+      Host:
+      - cdn.contentful.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3264'
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Cf-Space-Id:
+      - FAKE_SPACE_ID
+      Cf-Environment-Id:
+      - master
+      Cf-Environment-Uuid:
+      - 1bae0c6c-9bf9-4c44-9420-7099ae5e9248
+      Cf-Organization-Id:
+      - 3za11RVJBwLIPn20QJ67Gq
+      X-Contentful-Route:
+      - "/spaces/:space/environments/:environment/entries"
+      Etag:
+      - W/"15361090127068948762"
+      X-Contentful-Upstream-Request-Time:
+      - '0.051'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - Contentful
+      X-Contentful-Region:
+      - us-east-1
+      Contentful-Api:
+      - cda
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Resource-Resolution
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '86400'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,OPTIONS
+      Content-Encoding:
+      - gzip
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '484310'
+      Date:
+      - Wed, 07 May 2025 08:52:52 GMT
+      X-Served-By:
+      - cache-ewr-kewr1740029-EWR, cache-lhr-egll1980021-LHR
+      X-Cache-Hits:
+      - 3, 0
+      X-Timer:
+      - S1746607973.756373,VS0,VE214
+      X-Cache:
+      - HIT
+      X-Contentful-Request-Id:
+      - 7917a04e-20b1-40fc-8b2e-04078fea3812
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1cW3OqShZ+n19h+RzZNFfhTZOYaLKNRk1MpqamAFtFEQgXje46/31Wgyhu4Ww1EpyaeUhVpBfNpb9e61s3fhXdpVuUfxW9pY2LcrHiOMqy+NdV0bM8xSjK0lXRnep2UaavioY+072ijGj4X/fwDM7756/iDHvKQPGUYBJlRA7+66qoWaaGbS/4BbOtL+LaigZX+fXbRR91c1ok85vTbngbnUAQLjOAe7IEzR0jVpigiVP8C2YLjqLKi6/NOlgaDRr9Dw5NBTRrt+Cc9ZPcmp6zhJ+agxUPDypw50WGZvgSzZaQ0GUYmeFlhqNYiXkHMd+Gh9gRA0nUpcsyI8qMQNEST8SwOdcdy5xhE+bbPEdwQzPF9bCzvYH9p7qNnUyew/ZVQ3fHePCCHVe3zKLMMldFB8/18BdCwYv04GLhe/nzi7uOia9flAbPNbLgXZBLGpamGGShsVnqdchCD3VsDEII6F4wdA0nOLo5gkcZYFdzdNsLbq5Y9ZeFoWUNrgoDGJ8WFHNQILMT4YKLnbmuYRfOcg1/BOLRUGkE57glkC65vm0beijkq+s7I78JknaRmPT6whUN3raoVWpD9f19VfmUepNZF9U63fc6ecYjJ+LenEZDpZ3KY/NBa4q9Z1R+4G9gIkCxgw0Cin+vF+H4u+y+NEZDWtLarTpu37EjX3RqNTJ3cJ95bR2BZ7Qx/5OvNJU7Y1y1ePWtPLk5bOswqItomRfInhDFYE+kbx2akXmWQozwHVunfAFbp95N3DT1brBX6tfdAv7wdZuoj+DI/qYBDQsb6Gt7gys32xXVVBfMlGt1GfF11mPH+gl7g63P6u/s2GhPhr25ihbMzfSlOT1hIqSX1a646g9HVr0yX7y0P4ePff+UiWqavio3Gjb3oFf8qdgfvausfcJEbJVZzcUK/TQb06tp54W9e7FhDxyvP4Q3p35f1fVO76PjDozJz+tJrwya9XhF1K/2zfEdN2yJ11XW/Hij7fZD44SJhAdLWowndOdJXCjtVcOu1dHcOmEitu3YldXPlfkqNAcC47La7L7xDBOdQzWi6urVvm7i+qr1+nzjjduTz0fjnkyeq24UHz7uMf3I1N5VbrjsVaz2q66Kh+hGpkTzXYRkTpJZRNHsn3QjLbNlimPRN+hGhtvRjcDfcqAVNd1UgBQmKshhMKYrRoJGnOOxrhm4NNYdHJAI23e0seKSmb5soF/w6+KFF9zG7afiVNt4ONGmbu4gFEzO7N+qT32ts1B/9m84zumz6iEgjHPbMkULdLKB5kos3UW8zNIyQhTPsN8AQla4AAP9jDXH1z1igK8K98+BEfYcRTfT+K7rKUNAJ/Bby/AJD3YLxECHDDegs8uShxVtDBS+FAgHGB0TR+DL6ESd9mjSqDm3vtq9WfL0VJo/9R5zh6fID9Tqgm/T07u5+DLXOsL82mscAs+YjmQkikbS38OTkWROpBDNfQc8+QuA5xNgTcMBKvHAB/8IAFeIOU37/pjieG7oiDnKEP6NhK8KAEZyOnaWwbjlAUS39HMLYs1QXNexrFncO/sydNlbSUWq0VGnuvm0aNXGrWujrOUOXaYxHkyqA4N5vqt+2HeryaLFrUjw4aioAaLQnzQrBBc4DqBb/gbocpfg+tQUTTd0D5z5wkwxlRHeODmYIDHw+ffhO0w8a98tGjmWb0IQYQaqGuIhhEgEenY79xd9JtZpv0qtYae2+Hn/MG5NnI+Xzs9THAtO4Yeiq04fav1l03to2mPmfemdiTSzwuOHaTa0lUYrq/6q9dSV3qx+7rvqnddtjfnw6ObD42zSfZtK5ceHIzcVy0M84U/2ADgzhOLQt9gDccceAIPOgTNDOM/1DQ/gvowz4/19ZDvWELskbJjIoeHWo3nOwUuYGUaiPfiQ7gy/jueTpjaeldsneJjopncrcGr5/nooPTc/eeGxgj9JXCBfJ5Bnn+h6y+8q3vuEnQ3pnrF8AuN1gJWIiDWCoLFIsWIQ+doPkCWKZRxb3uU3ucD5EY8gqZBkBwwykuD8BcfPAdkLRZpwX1eG7+8QPmIfm5zLq/OONe4fgrQ4lRYoXgriCH+DNEh2CJSEAocwY6Rxl0Clb4H5jkgCaF9ZYgNrnqNrure8KowU9ypGkIc+NmI5DBzN8kV6Ia6e6KeHt/f5ajUZidpAadRf2ZMiqcq8vVJnyqDqXb+2fO1+8YyZtxNUL9NBy5rCLWfVUb+KvWfmbSZMT5mI6wlK+7nr+60Hlr3T6OnNzOuf8miMVGkZj5Vaf/ju9SrMcj6bWIvPMzEnZj6adwcLRZya4kdv+tN7WcE7DC0NhDN1UzN8QApJ6oWZw1xzm8mx0QPsD1siCRpWZiAOKVDlNEKVKJaxVth1Us5hf353Uv+U4CQJ5n97+JOkgrtjCOq4Bc8qEG6kD8A3XoyxWVD9JYn2BIkc34EMeHHsebYr//ixWCyokTWn/OmPka8PiAvyI5QuDS2n5GpjyzLckhdMXPKsUjRxScUggEtLyycRIsf7oWte4L1o1sz2IX9aGisOYNPB4T7OKy+YYiOPgB3Ly4ijeE5MNkYR7HbEMoYdu0PjLxB2IToKgA4CvsIeE8oMhSG3yjXbgpLTeYchDiLYgkwjkmIWQpcwnf5AEQfHUjQfADNjxO0oOijo+LrfuCUfh1dxNLG3sByIvo3CcCKoG9BJODHpDEfXg6V16CVnRZQc9z4MFoH9YxlABsVyQWJjHxYbRRQXyxgWu+mPc8DizPbvN0W0zo7YytKxjB3fLDONNHbCBF94yQiLJB+XY7UMSmbch4ExyLJxnMyCVUwLBgAY98UyBuP5reIpOupOibla5Ee+C51cpHLwQoMxgsoohirT6fQntFlxsYwXejfzfw6tc8pCXy9VINgu1nwHnG5QyVGJIDkO+3x9PNflT3E/D15+2OeQUEcUJwbh6USjE+7zuFjGy3/+oN8py1/VwYBAilwL6EhEMTYoUGG4FA1fBgNJiY4cAQZGkDmaEvnUlAZT7iJOBq7Ci5HKyBgMpJ54W12cGzOtzyBbMceFMLZWwCTnrWNIcWz1gh6KAF0lQbxSTCRfFZGc9zgMFWFcBioaaAqVU4rDNnGZuFjGqDi/hciWl8ZyWfGEQWakNHa90qYoQzE27DSgrBA61Edm8K/q68YgXyaTEuw8AqdQGMYx4C+n1I9t/Ke42P86TuPxw03eIDNYrq+Qqz5MKUc4AmdMWaZ5iFOn5Ek3+jAuljHOzu8aZawPDaysyxczAxvU3wbXuBCXPKV4/zDchS6YKNPQwMKk9H6FLjk4dHGxjHF3GVS9bkKuYhYWHsbquKA3K+j423D2mBwUZUX1XqVILl+1lFx7eBg8QprGkdZABqU48kFrIJT6MyAG5J35jqgy2uFpZyHv2eol6w+1rJkpK9WypmG7YZyuOdi1oHEAUrz5YjO5peowbEbRIySC6kqJMkSlRZDxoBlKCOtCMlZdO6VyZ4HmKVGGa8PygX5DZwg01kXV+rFYUzC8HcgXBsmtVcfAgCUZLVROUVEbGJRlvkyV0Xd0L18GDO6jXPrGVl1Gdj2lwvjgJYf4oiRD14TIpYaUwqYeaG3npCj3lfHORztsObetfxeWh0Pl+aY8PMx6bkrP1wHntPrxXJVBSr/uEcjgoeeQpxD3t3SWl3fEMkbG+cNKp9iEqmMpA5X0v5C/hT7UtwZhMxaEbYKxfGGQXEh3MAwg4AwftWApSQqaTvYTEBubgGRaohgm0CMZw+AybEILe5DEjpV5Gjr04Q8Kv1V7hkdL4dF8sZDcDH4AFpgSYrqIkZEkI4FCYqpKQOUuuLcsRJqh84L+diyA4cinMKZjDb2g1m7bxhkdyXfJkz9EcsCSRwUEbED5JSY9aBs2/cbFMt7+l2EFoi/aJLY/rj9gU9p8mSNnK5DcP3YADDbqnSP8jxZSckyJYhnD4Pwx1VPIwPU2UhrVH0RHct35KR/sOGDJN3HKoKSADz8msW/4o09ZQVcSIAOJ3xKvuoxkcws+TgWt/pplQ68H4YCupphb1W+TYajDtpcBCQwG88VC8udkDsYCtPmAx89CtVlKYCAyFjtiGW//y7AC8BWm3T7ItRLQCQC2/ZG5Ln/KZ82OWH4gAZC5LUspQYIYV9iKZbz8l5HZ2JCA/e7yzZfqNkP5giC5WewIEEDFKV2mEJte/hxVnG7FMgbBZeiA223r39YIxPoB81X+yZ8LPGzdw7yVQKrJWDbV6Vt3h8XF/uvWPdu0VaQLSAQlq/6vC9M3yR/BOgJ2LKgbAruUuNOmWigu9n/YkaZAaPdSXFIUu/U+M8Td+mJbVzfeuQiqD7668I//AEerdPASWAAA
+  recorded_at: Wed, 07 May 2025 08:52:52 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Solutions_pages/when_displaying_call_to_action_button/includes_the_usability_survey_URL_with_service_and_return_url_params.yml
+++ b/spec/fixtures/vcr_cassettes/Solutions_pages/when_displaying_call_to_action_button/includes_the_usability_survey_URL_with_service_and_return_url_params.yml
@@ -1,0 +1,181 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cdn.contentful.com/spaces/FAKE_SPACE_ID/environments/master/entries?content_type=solution&fields.slug=it-hardware&include=1&select=fields.title,fields.description,fields.expiry,fields.related_content,fields.summary,fields.slug,fields.suffix,fields.provider_name,fields.call_to_action,fields.url,sys
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful.rb/2.17.1; platform ruby/3.4.1; os macOS/24;
+      Authorization:
+      - Bearer FAKE_API_KEY
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
+      Host:
+      - cdn.contentful.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1108'
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Cf-Space-Id:
+      - FAKE_SPACE_ID
+      Cf-Environment-Id:
+      - master
+      Cf-Environment-Uuid:
+      - 1bae0c6c-9bf9-4c44-9420-7099ae5e9248
+      Cf-Organization-Id:
+      - 3za11RVJBwLIPn20QJ67Gq
+      X-Contentful-Route:
+      - "/spaces/:space/environments/:environment/entries"
+      Etag:
+      - W/"5579659512081360399"
+      X-Contentful-Upstream-Request-Time:
+      - '0.106'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - Contentful
+      X-Contentful-Region:
+      - us-east-1
+      Contentful-Api:
+      - cda
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Resource-Resolution
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '86400'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,OPTIONS
+      Content-Encoding:
+      - gzip
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '5744'
+      Date:
+      - Wed, 07 May 2025 10:28:36 GMT
+      X-Served-By:
+      - cache-ewr-kewr1740089-EWR, cache-lhr-egll1980052-LHR
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1746613716.177967,VS0,VE1
+      X-Cache:
+      - HIT
+      X-Contentful-Request-Id:
+      - 9623453c-f693-491e-84d5-eebf0055e6a1
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA9VWbW/bNhD+vl9BKF8tWZIdx9G3NFvRANnQNc6CpSkCmjpZTChS4ItfEuS/70jJtdumaAY0GAYYsEXfnXh3zz3PPUZmY6LiMbKbFqIiOtGabqKnQWSVpSIqskFk7nkbFekgErzhFo9S/M0tNOj38TGqOIiyC8Gt8DHOZuQd1eWKaogGUQmGad5arqSPTyonBNFULoCoiqBt3dsSLplwJZcLImE1IBoqp+fc1FAOCJUlHjRUuooy6zSUCTmzhAqjej8waNBSrgek5KZVhorgRY1RjFMLJTGgl5yh4e5NxrWt0hgILRvKpQVJJfP3hnXL9QavnKf5YZxO41E2S9MifJI0Ta/RRoPwgW+Z8o5YG6zHl/U85/IeDQV+zboK/yYthsUKlhg7e/Nw1Z7+AWcP768+/GrrP+/W5+Jd9PT0CevumoaGGxwckKuaWsItlqwCbcjBwY2c1dyQStMGVkrfE3wwrUATTEKRSjlNzpU1IbNWqyXHRhD6/yh/ciNvJGb9BiRUHJPw+caEqaYFyy1fAqbEmYeKT8+0gB0W+L8s8V8lDYE1Ysl4QywGlI5Rf+6DADUbf+gMkBW3NZYQIIQJyNwCotKqIbb2L1IM8dZgf3cAskAbH0zp0reDUUnmaCooQ5gtOUUIamAIKxwChGAIrjGa3uXgb4MwMMItsMXcxts58Ieuqvjaj+W/QtPkZJPb5vrhMvuQO3bK5PzCZm8RTYOoR4C+lYgXfN/7vawu+rHAFzuNMx/V1ramGA5Xq1Wyl/52fBKmEnc/RITFRgkXCj78DEQztMBqqYRabIb7aeEt+mxMi3V6SXYXwbCfFTVhps5Gk7vsToecwgRNW51drnV5Tc+Xf2f0+PeTeZ6hS89n22ljGvyknuCM9gM9irPJLM+LfFKMxslRPvUD7dryK7NxnOezLCvGeZEeJ+PDsTcDueRaSY+JvTTCfRpqLOjdBZ4jgJ1zaI2bi8ByfyGUAkvmY08tS949ZcjBPcF0FPJjVJx2fBTM+zptOxUqJxSjgapBxpcXHd10nAiBybuqeTZrwFIsCQ0SQRee8pGa8DoMWhueXqet3yHGF/U1z2bZqMixZ5NkenT8fF9H8TNmr9zX6Rdt/Rld/VqAnmvuYE+ivQ7dWlj7MUD9kAvjqRDbaVAeNFnVgETmNp5Yz2Z+Hr7hg4Va+uFfOF56oRx21nGlkAxYrZQwsQ2BY6vibeB4DmgA8Ua52Fiq7ZAzGyMtokXTOhyYHfthCv8d7L7DoC+A3ZYnRtNilCVH2eHzsEOz6Sw9LtJxMTpMjieBdV4ZdpN92OU/A3a9Pv0IbSjVgWXefl5SesdvtkIU3p2AdFtd2HQKvwh0wi+4x1sn2V6XEfqwpCjK+wKtYeFwJfOK5P28mAvuFbpF9LEa2D3q8xz1HwPQ1osiPu92qK1Kel/vQRe4G5QE8dl0i9Ruw/Ck+fT0yz95e1KgQAsAAA==
+  recorded_at: Wed, 07 May 2025 10:28:36 GMT
+- request:
+    method: get
+    uri: https://cdn.contentful.com/spaces/FAKE_SPACE_ID/environments/master/entries?content_type=category&fields.slug
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful.rb/2.17.1; platform ruby/3.4.1; os macOS/24;
+      Authorization:
+      - Bearer FAKE_API_KEY
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
+      Host:
+      - cdn.contentful.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3264'
+      Content-Type:
+      - application/vnd.contentful.delivery.v1+json
+      Cf-Space-Id:
+      - FAKE_SPACE_ID
+      Cf-Environment-Id:
+      - master
+      Cf-Environment-Uuid:
+      - 1bae0c6c-9bf9-4c44-9420-7099ae5e9248
+      Cf-Organization-Id:
+      - 3za11RVJBwLIPn20QJ67Gq
+      X-Contentful-Route:
+      - "/spaces/:space/environments/:environment/entries"
+      Etag:
+      - W/"15361090127068948762"
+      X-Contentful-Upstream-Request-Time:
+      - '0.051'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - Contentful
+      X-Contentful-Region:
+      - us-east-1
+      Contentful-Api:
+      - cda
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Resource-Resolution
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '86400'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,OPTIONS
+      Content-Encoding:
+      - gzip
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '490053'
+      Date:
+      - Wed, 07 May 2025 10:28:36 GMT
+      X-Served-By:
+      - cache-ewr-kewr1740029-EWR, cache-lhr-egll1980074-LHR
+      X-Cache-Hits:
+      - 3, 0
+      X-Timer:
+      - S1746613716.271890,VS0,VE1
+      X-Cache:
+      - HIT
+      X-Contentful-Request-Id:
+      - 68d42897-4d43-44fc-a41b-83d9691f6cd8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1cW3OqShZ+n19h+RzZNFfhTZOYaLKNRk1MpqamAFtFEQgXje46/31Wgyhu4Ww1EpyaeUhVpBfNpb9e61s3fhXdpVuUfxW9pY2LcrHiOMqy+NdV0bM8xSjK0lXRnep2UaavioY+072ijGj4X/fwDM7756/iDHvKQPGUYBJlRA7+66qoWaaGbS/4BbOtL+LaigZX+fXbRR91c1ok85vTbngbnUAQLjOAe7IEzR0jVpigiVP8C2YLjqLKi6/NOlgaDRr9Dw5NBTRrt+Cc9ZPcmp6zhJ+agxUPDypw50WGZvgSzZaQ0GUYmeFlhqNYiXkHMd+Gh9gRA0nUpcsyI8qMQNEST8SwOdcdy5xhE+bbPEdwQzPF9bCzvYH9p7qNnUyew/ZVQ3fHePCCHVe3zKLMMldFB8/18BdCwYv04GLhe/nzi7uOia9flAbPNbLgXZBLGpamGGShsVnqdchCD3VsDEII6F4wdA0nOLo5gkcZYFdzdNsLbq5Y9ZeFoWUNrgoDGJ8WFHNQILMT4YKLnbmuYRfOcg1/BOLRUGkE57glkC65vm0beijkq+s7I78JknaRmPT6whUN3raoVWpD9f19VfmUepNZF9U63fc6ecYjJ+LenEZDpZ3KY/NBa4q9Z1R+4G9gIkCxgw0Cin+vF+H4u+y+NEZDWtLarTpu37EjX3RqNTJ3cJ95bR2BZ7Qx/5OvNJU7Y1y1ePWtPLk5bOswqItomRfInhDFYE+kbx2akXmWQozwHVunfAFbp95N3DT1brBX6tfdAv7wdZuoj+DI/qYBDQsb6Gt7gys32xXVVBfMlGt1GfF11mPH+gl7g63P6u/s2GhPhr25ihbMzfSlOT1hIqSX1a646g9HVr0yX7y0P4ePff+UiWqavio3Gjb3oFf8qdgfvausfcJEbJVZzcUK/TQb06tp54W9e7FhDxyvP4Q3p35f1fVO76PjDozJz+tJrwya9XhF1K/2zfEdN2yJ11XW/Hij7fZD44SJhAdLWowndOdJXCjtVcOu1dHcOmEitu3YldXPlfkqNAcC47La7L7xDBOdQzWi6urVvm7i+qr1+nzjjduTz0fjnkyeq24UHz7uMf3I1N5VbrjsVaz2q66Kh+hGpkTzXYRkTpJZRNHsn3QjLbNlimPRN+hGhtvRjcDfcqAVNd1UgBQmKshhMKYrRoJGnOOxrhm4NNYdHJAI23e0seKSmb5soF/w6+KFF9zG7afiVNt4ONGmbu4gFEzO7N+qT32ts1B/9m84zumz6iEgjHPbMkULdLKB5kos3UW8zNIyQhTPsN8AQla4AAP9jDXH1z1igK8K98+BEfYcRTfT+K7rKUNAJ/Bby/AJD3YLxECHDDegs8uShxVtDBS+FAgHGB0TR+DL6ESd9mjSqDm3vtq9WfL0VJo/9R5zh6fID9Tqgm/T07u5+DLXOsL82mscAs+YjmQkikbS38OTkWROpBDNfQc8+QuA5xNgTcMBKvHAB/8IAFeIOU37/pjieG7oiDnKEP6NhK8KAEZyOnaWwbjlAUS39HMLYs1QXNexrFncO/sydNlbSUWq0VGnuvm0aNXGrWujrOUOXaYxHkyqA4N5vqt+2HeryaLFrUjw4aioAaLQnzQrBBc4DqBb/gbocpfg+tQUTTd0D5z5wkwxlRHeODmYIDHw+ffhO0w8a98tGjmWb0IQYQaqGuIhhEgEenY79xd9JtZpv0qtYae2+Hn/MG5NnI+Xzs9THAtO4Yeiq04fav1l03to2mPmfemdiTSzwuOHaTa0lUYrq/6q9dSV3qx+7rvqnddtjfnw6ObD42zSfZtK5ceHIzcVy0M84U/2ADgzhOLQt9gDccceAIPOgTNDOM/1DQ/gvowz4/19ZDvWELskbJjIoeHWo3nOwUuYGUaiPfiQ7gy/jueTpjaeldsneJjopncrcGr5/nooPTc/eeGxgj9JXCBfJ5Bnn+h6y+8q3vuEnQ3pnrF8AuN1gJWIiDWCoLFIsWIQ+doPkCWKZRxb3uU3ucD5EY8gqZBkBwwykuD8BcfPAdkLRZpwX1eG7+8QPmIfm5zLq/OONe4fgrQ4lRYoXgriCH+DNEh2CJSEAocwY6Rxl0Clb4H5jkgCaF9ZYgNrnqNrure8KowU9ypGkIc+NmI5DBzN8kV6Ia6e6KeHt/f5ajUZidpAadRf2ZMiqcq8vVJnyqDqXb+2fO1+8YyZtxNUL9NBy5rCLWfVUb+KvWfmbSZMT5mI6wlK+7nr+60Hlr3T6OnNzOuf8miMVGkZj5Vaf/ju9SrMcj6bWIvPMzEnZj6adwcLRZya4kdv+tN7WcE7DC0NhDN1UzN8QApJ6oWZw1xzm8mx0QPsD1siCRpWZiAOKVDlNEKVKJaxVth1Us5hf353Uv+U4CQJ5n97+JOkgrtjCOq4Bc8qEG6kD8A3XoyxWVD9JYn2BIkc34EMeHHsebYr//ixWCyokTWn/OmPka8PiAvyI5QuDS2n5GpjyzLckhdMXPKsUjRxScUggEtLyycRIsf7oWte4L1o1sz2IX9aGisOYNPB4T7OKy+YYiOPgB3Ly4ijeE5MNkYR7HbEMoYdu0PjLxB2IToKgA4CvsIeE8oMhSG3yjXbgpLTeYchDiLYgkwjkmIWQpcwnf5AEQfHUjQfADNjxO0oOijo+LrfuCUfh1dxNLG3sByIvo3CcCKoG9BJODHpDEfXg6V16CVnRZQc9z4MFoH9YxlABsVyQWJjHxYbRRQXyxgWu+mPc8DizPbvN0W0zo7YytKxjB3fLDONNHbCBF94yQiLJB+XY7UMSmbch4ExyLJxnMyCVUwLBgAY98UyBuP5reIpOupOibla5Ee+C51cpHLwQoMxgsoohirT6fQntFlxsYwXejfzfw6tc8pCXy9VINgu1nwHnG5QyVGJIDkO+3x9PNflT3E/D15+2OeQUEcUJwbh6USjE+7zuFjGy3/+oN8py1/VwYBAilwL6EhEMTYoUGG4FA1fBgNJiY4cAQZGkDmaEvnUlAZT7iJOBq7Ci5HKyBgMpJ54W12cGzOtzyBbMceFMLZWwCTnrWNIcWz1gh6KAF0lQbxSTCRfFZGc9zgMFWFcBioaaAqVU4rDNnGZuFjGqDi/hciWl8ZyWfGEQWakNHa90qYoQzE27DSgrBA61Edm8K/q68YgXyaTEuw8AqdQGMYx4C+n1I9t/Ke42P86TuPxw03eIDNYrq+Qqz5MKUc4AmdMWaZ5iFOn5Ek3+jAuljHOzu8aZawPDaysyxczAxvU3wbXuBCXPKV4/zDchS6YKNPQwMKk9H6FLjk4dHGxjHF3GVS9bkKuYhYWHsbquKA3K+j423D2mBwUZUX1XqVILl+1lFx7eBg8QprGkdZABqU48kFrIJT6MyAG5J35jqgy2uFpZyHv2eol6w+1rJkpK9WypmG7YZyuOdi1oHEAUrz5YjO5peowbEbRIySC6kqJMkSlRZDxoBlKCOtCMlZdO6VyZ4HmKVGGa8PygX5DZwg01kXV+rFYUzC8HcgXBsmtVcfAgCUZLVROUVEbGJRlvkyV0Xd0L18GDO6jXPrGVl1Gdj2lwvjgJYf4oiRD14TIpYaUwqYeaG3npCj3lfHORztsObetfxeWh0Pl+aY8PMx6bkrP1wHntPrxXJVBSr/uEcjgoeeQpxD3t3SWl3fEMkbG+cNKp9iEqmMpA5X0v5C/hT7UtwZhMxaEbYKxfGGQXEh3MAwg4AwftWApSQqaTvYTEBubgGRaohgm0CMZw+AybEILe5DEjpV5Gjr04Q8Kv1V7hkdL4dF8sZDcDH4AFpgSYrqIkZEkI4FCYqpKQOUuuLcsRJqh84L+diyA4cinMKZjDb2g1m7bxhkdyXfJkz9EcsCSRwUEbED5JSY9aBs2/cbFMt7+l2EFoi/aJLY/rj9gU9p8mSNnK5DcP3YADDbqnSP8jxZSckyJYhnD4Pwx1VPIwPU2UhrVH0RHct35KR/sOGDJN3HKoKSADz8msW/4o09ZQVcSIAOJ3xKvuoxkcws+TgWt/pplQ68H4YCupphb1W+TYajDtpcBCQwG88VC8udkDsYCtPmAx89CtVlKYCAyFjtiGW//y7AC8BWm3T7ItRLQCQC2/ZG5Ln/KZ82OWH4gAZC5LUspQYIYV9iKZbz8l5HZ2JCA/e7yzZfqNkP5giC5WewIEEDFKV2mEJte/hxVnG7FMgbBZeiA223r39YIxPoB81X+yZ8LPGzdw7yVQKrJWDbV6Vt3h8XF/uvWPdu0VaQLSAQlq/6vC9M3yR/BOgJ2LKgbAruUuNOmWigu9n/YkaZAaPdSXFIUu/U+M8Td+mJbVzfeuQiqD7668I//AEerdPASWAAA
+  recorded_at: Wed, 07 May 2025 10:28:36 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
JIRA ticket - https://dfedigital.atlassian.net/browse/FB-230

- Add a link to a Usability Survey on the Solution show page.
- Clicking on the CTA button takes the user to the usability survey hosted on the GHBS website.
- The Solution url is included as an HMAC encoded string, which is verified by the GHBS app before redirecting the user to it
- CTA link is preserved so the user can copy the link for sharing
- Clicks are tracked as before in dfe-analytics
- Add specs