### PR TITLE
Switch dfe-analytics from fork to official gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "contentful"
 gem "contentful-management", require: false
 gem "cssbundling-rails"
 gem "csv", require: false
-gem "dfe-analytics", github: "hrmtl/dfe-analytics", branch: "make-activerecord-optional"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.6"
 gem "dotenv"
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
-  remote: https://github.com/hrmtl/dfe-analytics.git
-  revision: 3acbed0cb89c80bff65415b08110d16f5601ad0c
-  branch: make-activerecord-optional
+  remote: https://github.com/DFE-Digital/dfe-analytics.git
+  revision: 14be35cf91c1ca86a18bd87243444cb3e2d9fae2
+  tag: v1.15.6
   specs:
-    dfe-analytics (1.15.5)
+    dfe-analytics (1.15.6)
       google-cloud-bigquery (~> 1.38)
       httparty (~> 0.21)
       multi_xml (~> 0.6.0)
@@ -129,7 +129,7 @@ GEM
     dotenv (3.1.8)
     drb (2.2.1)
     erubi (1.13.1)
-    faraday (2.13.0)
+    faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -148,9 +148,9 @@ GEM
       rake
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-apis-bigquery_v2 (0.86.0)
+    google-apis-bigquery_v2 (0.88.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-core (0.16.0)
+    google-apis-core (0.17.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 1.9)
       httpclient (>= 2.8.3, < 3.a)
@@ -158,7 +158,7 @@ GEM
       mutex_m
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
-    google-cloud-bigquery (1.52.0)
+    google-cloud-bigquery (1.52.1)
       bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
       google-apis-bigquery_v2 (~> 0.71)
@@ -169,11 +169,11 @@ GEM
     google-cloud-core (1.8.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
-    google-cloud-env (2.2.2)
+    google-cloud-env (2.3.0)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.5.0)
-    google-logging-utils (0.1.0)
+    google-logging-utils (0.2.0)
     googleauth (1.14.0)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
@@ -442,7 +442,7 @@ GEM
       logger (>= 1.6.2)
       rack (>= 3.1.0)
       redis-client (>= 0.23.2)
-    signet (0.19.0)
+    signet (0.20.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)


### PR DESCRIPTION
We've been using a fork of the `dfe-analytics` gem. Now the official gem has our changes in a[ tagged release](https://github.com/DFE-Digital/dfe-analytics/blob/main/CHANGELOG.md#v1156-2025-04-30), so this PR switches to using that.