### PR TITLE
FB-233 - The home page search bar changes for mobile

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -229,11 +229,22 @@ footer {
     width: 650px;
   }
 }
+div.homepage_search.dfe-header__search-wrap {
+  display: block !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  height: auto !important;
+  overflow: visible !important;
+}
 
 .dfe-search__submit {
   background: #a2d5f5;
 }
 
+.dfe-header__search-form {
+  background-color: #003a69;
+  padding: 0px;
+}
 .search-results-section{
   border-bottom: 1px solid #b1b4b6;
   margin-top: 10px;

--- a/app/views/shared/_dfe_homepage_header.html.erb
+++ b/app/views/shared/_dfe_homepage_header.html.erb
@@ -10,7 +10,7 @@
           <h3 class="dfe-body-l header_description">
             <%= t('header_description') %>
           </h3>
-          <%= render "shared/dfe_search" %>
+          <%= render "shared/dfe_search_homepage" %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_dfe_logo_and_menu.html.erb
+++ b/app/views/shared/_dfe_logo_and_menu.html.erb
@@ -1,4 +1,4 @@
-<div class="dfe-width-container dfe-header__container">
+<div class="dfe-width-container dfe-header__container clearfix">
   <div class="dfe-header__logo">
     <a class="dfe-header__link" href="/" aria-label="DfE homepage">
       <%= image_tag 'dfe-frontend/dfe-logo.png', class: 'dfe-logo', alt: 'Department for Education' %>
@@ -7,12 +7,9 @@
   </div>
   <div class="dfe-header__content" id="content-header">
     <%= render "shared/dfe_narrow_search_box" if @show_search_in_header %>
-    <div class="dfe-header__menu">
-      <button class="dfe-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-expanded="false"><%= t(".menu") %></button>
-    </div>
   </div>
 </div>
 
-<div class="dfe-width-container dfe-header__service-name">
+<div class="dfe-width-container dfe-header__service-name clearfix">
   <a href="/" class="dfe-header__link--service"><%= t("header_title") %></a>
 </div>

--- a/app/views/shared/_dfe_search_homepage.html.erb
+++ b/app/views/shared/_dfe_search_homepage.html.erb
@@ -1,0 +1,14 @@
+  <div class="dfe-header__search govuk-!-margin-left-0">
+    <div class="homepage_search dfe-header__search-wrap" id="wrap-search">
+      <form class="dfe-header__search-form" id="search" action="/search" method="get" role="search">
+        <label class="govuk-visually-hidden" for="search-field"><%= t(".search_this_website") %></label>
+        <input class="dfe-search__input" id="search-field" name="query" type="search" placeholder="Search" autocomplete="off" value="<%= params[:query] %>">
+        <button class="dfe-search__submit" type="submit">
+          <svg class="dfe-icon dfe-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
+            <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+          </svg>
+          <span class="govuk-visually-hidden"><%= t(".search") %></span>
+        </button>
+      </form>
+    </div>
+  </div>


### PR DESCRIPTION
 Issue -  https://dfedigital.atlassian.net/browse/FB-233

- The home page search bar partial is created and is expanded for all mobile devices too.
 - The menu item has been removed

Desktop now has search text as placeholder in the input text box:

<img width="1633" alt="Screenshot 2025-05-22 at 14 45 48" src="https://github.com/user-attachments/assets/cb06c22e-dd5a-4c07-832d-aff9934a5dbd" />

Mobile has the search expanded too just for the homepage:

<img width="779" alt="Screenshot 2025-05-22 at 14 47 07" src="https://github.com/user-attachments/assets/75684498-3688-4bb1-b9fa-204fae15f1af" />
