### PR TITLE
Copy fixes

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -348,7 +348,6 @@ div.homepage_search.dfe-header__search-wrap {
     -webkit-line-clamp: 5;
     -webkit-box-orient: vertical;
     word-wrap: break-word;
-    hyphens: auto;
   }
 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,7 +18,7 @@ en:
     formats:
       standard: "%e %B %Y"
   header_description: A free and compliant service to help you buy for your school,
-    trust or academy.
+    trust or academy
   header_title: Get help buying for schools
   results:
     count:
@@ -48,7 +48,7 @@ en:
   shared:
     dfe_beta_banner:
       banner_text_html: This is a new service - your %{feedback} will help us to improve
-        it.
+        it
       beta: BETA
       feedback: feedback
     dfe_footer:

--- a/public/application.css
+++ b/public/application.css
@@ -9951,7 +9951,6 @@ footer {
   -webkit-line-clamp: 5;
   -webkit-box-orient: vertical;
   word-wrap: break-word;
-  hyphens: auto;
 }
 
 .dfe-card-container {


### PR DESCRIPTION
Small copy fixes: 

- Remove periods from header and beta banner.
- Don't hyphenate long words on category tiles