### PR TITLE
Fix host config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,9 +28,6 @@ module FindABuyingSolution
     config.middleware.use RealIp
     config.middleware.use FafDomainRedirect
 
-    heroku_domain = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" if ENV["HEROKU_APP_NAME"].present?
-    config.hosts = [heroku_domain, ENV["APP_DOMAIN"], ENV["FAF_DOMAIN"]].compact
-
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,12 +53,9 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  heroku_domain = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" if ENV["HEROKU_APP_NAME"].present?
+  config.hosts = [heroku_domain, ENV["APP_DOMAIN"], ENV["FAF_DOMAIN"]].reject(&:blank?)
+
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
When I implemented handling FaF redirect (https://github.com/DFE-Digital/find-a-buying-solution/pull/154), I added a host config to `application.rb` but this broke development. 

In this PR, I've moved the host config to `production.rb`.