### PR TITLE
Only add external attributes to a tags with href

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -3,9 +3,10 @@ module MarkdownHelper
     return "" if markdown_content.blank?
 
     html = Kramdown::Document.new(markdown_content).to_html
-    doc = Nokogiri::HTML.fragment(html)
+    return html.html_safe unless html.include?("href")
 
-    doc.css("a").each do |link|
+    doc = Nokogiri::HTML.fragment(html)
+    doc.css("a[href]").each do |link|
       external_link_attributes(link["href"]).each do |key, value|
         link[key] = value
       end


### PR DESCRIPTION
Optimise Markdown links processing by only checking `a` tags with `href` attribute.