### PR TITLE
FB-337 Fix header bottom spacing bug on Safari

### DIFF
--- a/app/views/shared/_dfe_homepage_header.html.erb
+++ b/app/views/shared/_dfe_homepage_header.html.erb
@@ -1,4 +1,4 @@
-<header class="dfe-header" role="banner">
+<header class="dfe-header govuk-!-padding-bottom-7" role="banner">
   <%= render "shared/dfe_logo_and_menu" %>
   <section class="dfe-page-hero">
     <div class="dfe-width-container hero-text-container">
@@ -15,7 +15,7 @@
       </div>
     </div>
   </section>
-  <div class="dfe-width-container all-buying-options-link-container govuk-!-margin-top-4 govuk-!-margin-bottom-7">
+  <div class="dfe-width-container all-buying-options-link-container govuk-!-margin-top-4">
     <%= link_to  t(".view_all_buying_options"), solutions_path, class:"all-buying-options-link govuk-body underlined" %>
   </div>
 </header>


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/FB-337

Add bottom padding to `<header>` instead of margin below the link to fix a spacing bug.