### PR TITLE
Disable external link tracking because it's blocking opening all external links in Safari.

### DIFF
--- a/app/views/shared/_dfe_base.html.erb
+++ b/app/views/shared/_dfe_base.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 </head>
 
-<body class="govuk-template__body" data-controller="external-link-tracking engagement-tracking">
+<body class="govuk-template__body" data-controller="engagement-tracking">
   <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
   <%= yield %>
 </body>


### PR DESCRIPTION
Disable external link tracking because it's blocking opening all external links in Safari