### PR TITLE
FB-339 Open external links without preventing default click event

### DIFF
--- a/app/javascript/controllers/external_link_tracking_controller.js
+++ b/app/javascript/controllers/external_link_tracking_controller.js
@@ -19,31 +19,25 @@ export default class extends Controller {
   }
 
   async trackClick (event) {
-    event.preventDefault()
     const link = event.currentTarget
     const href = link.href
     const text = link.textContent.trim()
-    const surveyUrl = link.dataset.surveyUrl
 
-    try {
-      await fetch('/events', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
-        },
-        body: JSON.stringify({
-          event: {
-            type: 'external_link_clicked',
-            data: {
-              href,
-              text
-            }
+    await fetch('/events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({
+        event: {
+          type: 'external_link_clicked',
+          data: {
+            href,
+            text
           }
-        })
+        }
       })
-    } finally {
-      window.open(surveyUrl || href, '_blank', 'noopener,noreferrer')
-    }
+    })
   }
 }

--- a/app/views/solutions/show.html.erb
+++ b/app/views/solutions/show.html.erb
@@ -7,7 +7,7 @@
 
   <%= render partial: "shared/provider_and_expires", locals: { solution: @solution } %>
 
-  <%= fabs_govuk_link_to h(solution_cta(@solution)), @solution.url, class: "cta govuk-button", data: { survey_url: usability_survey_url(@solution.url) } %>
+  <%= fabs_govuk_link_to h(solution_cta(@solution)), usability_survey_url(@solution.url), class: "cta govuk-button" %>
 
   <% content_for :sidebar do %>
     <%= render partial: "shared/related_content", locals: { related_content: @solution.related_content } %>

--- a/spec/features/solutions_spec.rb
+++ b/spec/features/solutions_spec.rb
@@ -45,22 +45,18 @@ RSpec.describe "Solutions pages", :vcr, type: :feature do
   context "when displaying call to action button" do
     it "displays the default CTA text when no custom CTA is provided" do
       visit solution_path("it-hardware")
-      expect(page).to have_link("Visit the IT Hardware website",
-                                href: "https://www.procurementservices.co.uk/our-solutions/frameworks/technology/it-hardware",
-                                class: "govuk-button")
+      expect(page).to have_link("Visit the IT Hardware website", class: "govuk-button")
     end
 
     it "displays the custom CTA text when provided" do
       visit solution_path("ict-procurement")
-      expect(page).to have_link("Go to site",
-                                href: "https://www.everythingict.org/",
-                                class: "govuk-button")
+      expect(page).to have_link("Go to site", class: "govuk-button")
     end
 
     it "includes the usability survey URL with service and return_url params" do
       visit solution_path("it-hardware")
-      link = find("a.govuk-button[data-survey-url]", match: :first)
-      survey_url = link["data-survey-url"]
+      link = find("a.govuk-button[href]", match: :first)
+      survey_url = link["href"]
       uri = URI.parse(survey_url)
 
       expect(uri.host).to eq("www.get-help-buying-for-schools.service.gov.uk")


### PR DESCRIPTION
JIRA ticket - https://dfedigital.atlassian.net/browse/FB-339

Safari is blocking all external link clicks because we intercept the click with JavaScript to capture the event in analytics.

This PR is an attempt to avoid that blocking by not calling `event.preventDefault()`. 
