### PR TITLE
FB-318-The related content is now coded as a unordered list without bullets

### DIFF
--- a/app/views/shared/_related_content.html.erb
+++ b/app/views/shared/_related_content.html.erb
@@ -1,11 +1,12 @@
 <% if related_content.present? %>
   <div class="related-content govuk-!-margin-top-5">
     <h3 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-top-2"><%= t("shared.dfe_sidebar.related_content") %></h3>
-
-    <% related_content.each do |link| %>
-      <p class="govuk-!-margin-bottom-2">
-        <%= fabs_govuk_link_to link.link_text, link.url, class: "govuk-body-s" %>
-      </p>
-    <% end %>
+    <ul class="govuk-list">
+      <% related_content.each do |link| %>
+        <li>
+          <%= fabs_govuk_link_to link.link_text, link.url, class: "govuk-body-s" %>
+        </li>
+      <% end %>
+    </ul>
   </div>
 <% end %>


### PR DESCRIPTION
FB-318-Related-Items-as-unordered-list

Issue: https://dfedigital.atlassian.net/browse/FB-318
FB-318-The related content is now coded as a unordered list without bullets