### PR TITLE
FB-319 - Incorrect spacing on Buying options

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -557,7 +557,7 @@ a.all-buying-options-link {
 
 .gem-c-cards__list-item {
   border-top: 1px solid #b1b4b6;
-  padding: 5px 0 20px 0
+  padding: 5px 0 0 0
 }
 
 .gem-c-cards__list-item-wrapper {

--- a/app/views/shared/_solutions.html.erb
+++ b/app/views/shared/_solutions.html.erb
@@ -1,5 +1,5 @@
 <% if solutions.present? %>
-  <ul class="provider-expires gem-c-cards__list gem-c-cards__list--one-column govuk-!-margin-top-9">
+  <ul class="provider-expires gem-c-cards__list gem-c-cards__list--one-column">
     <% solutions.each do |solution| %>
       <li class="gem-c-cards__list-item">
         <div class="gem-c-cards__list-item-wrapper">

--- a/app/views/solutions/index.html.erb
+++ b/app/views/solutions/index.html.erb
@@ -15,7 +15,7 @@
 
       <div class="all-buying-options govuk-grid-column-two-thirds govuk-!-margin-top-4 govuk-!-margin-bottom-7">
         <% @sorted_categories.each do |category_slug, category_data| %>
-          <div class="all-buying-options-category">
+          <div class="all-buying-options-category govuk-!-margin-bottom-7">
             <h3 id="<%= category_slug.parameterize %>"><%= category_data[:slug] %></h3>
             <p><%= category_data[:description] %></p>
             <%= render partial: "shared/solutions", locals: { solutions: category_data[:solutions] } %>


### PR DESCRIPTION
Issue: https://dfedigital.atlassian.net/browse/FB-319

Solution:

- Reduced the spacing between the buying options heading and the solutions.
- Also reduced the spacing between each solution being listed.
- Added bottom margin to each category listed in the all-buying-options page