### PR TITLE
FB 359 - Update the colour of the service to match new gov.uk frontend (#1d70b8)

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -302,7 +302,7 @@ footer {
 
 .dfe-header {
   color: #fff;
-  background-color: govuk. $govuk-brand-colour;
+  background-color: govuk.$govuk-brand-colour;
 }
 
 .dfe-header__link:focus,

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -302,6 +302,7 @@ footer {
 
 .dfe-header {
   color: #fff;
+  background-color: govuk. $govuk-brand-colour;
 }
 
 .dfe-header__link:focus,


### PR DESCRIPTION
Issue: https://dfedigital.atlassian.net/browse/FB-359

Added  $govuk-brand-colour (#1d70b8) as the dfe-header background-colour

![Screenshot 2025-07-04 at 09 22 45](https://github.com/user-attachments/assets/4ade3bd3-50a7-4df0-995f-dfc6edbb50f8)


![Screenshot 2025-07-04 at 09 23 13](https://github.com/user-attachments/assets/2483c61b-4aa3-4008-b08b-2a0e1b429caa)
