### PR TITLE
Fb 376 - Update site to reflect new frontend colour scheme

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -502,6 +502,11 @@ a.all-buying-options-link {
     height: 100%;
 }
 
+.dfe-card:hover,
+.dfe-card:focus-within {
+  background-color: govuk.$govuk-brand-colour;
+}
+
 .govuk-footer {
   border-top: 1px solid #b1b4b6;
 }
@@ -726,4 +731,12 @@ a.all-buying-options-link {
   .gem-c-cards__link::after {
     position: static
   }
+}
+
+.category-header {
+  background-color: #d2e2f1;
+}
+
+.details-header {
+  background-color: #f4f8fb;
 }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -15,6 +15,7 @@ class CategoriesController < ApplicationController
     @selected_subcategories = @subcategories.select { params[:subcategory_slugs]&.include?(it.slug) }
     @solutions = @category.filtered_solutions(subcategory_slugs: params[:subcategory_slugs]&.compact_blank)
     @page_section_title = t(".section_title")
+    @page_header_class = "category-header"
     @page_title = @category.title
     @page_description = @category.description
   end

--- a/app/controllers/solutions_controller.rb
+++ b/app/controllers/solutions_controller.rb
@@ -25,6 +25,7 @@ class SolutionsController < ApplicationController
     @page_section_title = t(".section_title")
     @page_title = @solution.title
     @page_description = @solution.description
+    @page_header_class = "details-header"
     add_breadcrumb :home_breadcrumb_name, :home_breadcrumb_path
     add_breadcrumb :primary_category_breadcrumb_name, :primary_category_breadcrumb_path if @primary_category
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,13 @@
 <%= render "shared/dfe_base" do %>
   <%= render "shared/dfe_header" %>
-  <div class="page-header">
+  <div class="page-header <%= @page_header_class %>">
     <%= render "shared/dfe_beta_banner" %>
 
     <div class="main-container dfe-width-container">
        <%= render partial: "shared/breadcrumbs", locals: { govuk_breadcrumb_builder: govuk_breadcrumb_builder} %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          <div class="govuk-caption-m"><%= @page_section_title %></div>
+          <div class="govuk-caption-m "><%= @page_section_title %></div>
           <h1 class="govuk-heading-l"><%= @page_title %></h1>
           <p class="govuk-body-l">
             <%= @page_description %>


### PR DESCRIPTION
Issues
[https://dfedigital.atlassian.net/browse/FB-376](https://dfedigital.atlassian.net/browse/FB-376)

The [design](https://lucid.app/lucidspark/99574499-5a78-4da9-abf6-78207fd5de84/edit?view_items=Ycaye9V70d0_&invitationId=inv_04524c90-7810-4600-8a5b-3105bff9e0b6) can be found in lucid

Update: 
- Home Page hovers over any category tile it should appear as light blue. #1d70b8
- Category page -  page header background colour updated
- Details page -  page header background colour updated