### PR TITLE
FB-380 -remove I need something else link from the homepage

### DIFF
--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -5,9 +5,6 @@
       <%= render "category", category: category %>
     <% end %>
   </div>
-  <p class="govuk-body">
-    <%= govuk_link_to t(".procurement_support"), "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support", target: "_blank", rel: "noopener noreferrer" %>
-  </p>
   <% if @energy_banner %>
     <%= render partial: 'energy_banner', locals: { banner: @energy_banner } %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,6 @@ en:
       clear_all_filters: Clear all filters
       remove_filter: Remove filter
     index:
-      procurement_support: I need something else (opens in new tab)
       title: DfE-approved buying options by category
     show:
       apply: Apply

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -34,14 +34,6 @@ RSpec.describe "Categories pages", :vcr, type: :request do
       end
     end
 
-    it "includes the procurement support link with correct text" do
-      expect(response.body)
-        .to have_link(
-          "I need something else",
-          href: "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support"
-        )
-    end
-
     it "does not display categories without solutions" do
       expect(response.body).not_to include("category-no-solutions")
     end


### PR DESCRIPTION
Issues
[https://dfedigital.atlassian.net/browse/FB-380](https://dfedigital.atlassian.net/browse/FB-380)

Update
Remove the ‘I need something else link’ from the homepage. 