### PR TITLE
FB-221- RAILS_CACHE_EXPIRY needs to be added in CONFIG_VARS

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   rescue_from ContentfulRecordNotFoundError, with: :record_not_found
   before_action :enable_search_in_header, :set_default_back_link
+  before_action :reload_translations
 
 private
 
@@ -20,4 +21,13 @@ private
     @page_back_link ||= root_path
   end
   # rubocop:enable Naming/MemoizedInstanceVariableName
+
+  def reload_translations
+    # Reload the backend if Contentful translations cache has expired
+    unless Rails.cache.exist?(I18n::Backend::Contentful::CACHE_KEY)
+      Rails.logger.info "Cache expired. Reloading translations..."
+      I18n.backend.reload!
+    end
+  end
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,9 +46,9 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   config.cache_store = :redis_cache_store,
-                       {
-                         expires_in: 24.hours,
-                       }
+    {
+      expires_in: I18n::Backend::Contentful::CACHE_EXPIRY,
+    }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque

--- a/lib/i18n/backend/contentful.rb
+++ b/lib/i18n/backend/contentful.rb
@@ -7,7 +7,7 @@ module I18n
       include Flatten
 
       CACHE_KEY = "contentful_translations".freeze
-      CACHE_EXPIRY = 1.hour
+      CACHE_EXPIRY = ENV.fetch("RAILS_CACHE_EXPIRY", "24.hours").to_i
 
       def initialize
         @translations = Concurrent::Hash.new


### PR DESCRIPTION
- RAILS_CACHE_EXPIRY need to be added in CONFIG_VARS
- Default is 24.hours ( we can set it to 1.second for immediate effect )

Issue: https://dfedigital.atlassian.net/browse/FB-221