### PR TITLE
FB-361 css mobile fixes for the top search bar in the header

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1031,10 +1031,152 @@ a.all-buying-options-link {
 }
 
 @media (max-width: 40.0525em) {
+  .dfe-search__submit .dfe-icon__search .top-icon__search {
+    background-color: #1d70b8;
+    fill: black;
+    height: 27px;
+    width: 27px;
+  }
+}
+
+@media (max-width: 40.0525em) {
   .dfe-search__submit .dfe-icon__search {
       background-color: #d2e2f1;
       fill: black;
       height: 27px;
       width: 27px;
+  }
+}
+
+@media (max-width: 768px) { /* Adjust this breakpoint as needed for your definition of "mobile" */
+  .top_search_label {
+    display: block; /* Makes the label take up the full width, forcing the input to a new line */
+    margin-bottom: 5px; /* Add some space below the label */
+  }
+}
+
+.top-search__submit {
+  background: #1d70b8;
+  background-color: #1d70b8;
+  display: block;
+  height: 40px;
+  width: 44px;
+}
+
+.top-icon__search {
+  background-color: #1d70b8;
+  fill: #ffffff;
+  height: 27px;
+  width: 27px;
+}
+
+
+@media (min-width: 40.0625em) {
+  .top-icon__search {
+    height: 27px;
+    width: 27px;
+  }
+}
+
+@media (max-width: 40.0525em) {
+  .dfe-search__submit .dfe-icon__search .top-icon__search {
+    background-color: #1d70b8;
+    fill: black;
+    height: 27px;
+    width: 27px;
+  }
+}
+
+
+@media (max-width: 40.0525em) {
+  .dfe-search__submit .dfe-icon__search .top-icon__search {
+    background-color: #1d70b8;
+    fill: black;
+    height: 27px;
+    width: 27px;
+  }
+}
+@media (max-width: 40.0525em) {
+  .dfe-search__submit .dfe-icon__search {
+    background-color: #d2e2f1;
+    fill: black;
+    height: 27px;
+    width: 27px;
+  }
+}
+@media (max-width: 768px) { /* Adjust this breakpoint as needed for your definition of "mobile" */
+  .top_search_label {
+    display: inline-block; /* Makes the label take up the full width, forcing the input to a new line */
+    margin-bottom: 5px; /* Add some space below the label */
+  }
+}
+
+.top-icon__search {
+  background-color: #1d70b8;
+  fill: #ffffff;
+  height: 27px;
+  width: 27px;
+}
+
+.top-search__input {
+  border: 1px solid #ffffff;
+  font-size: 16px;
+  height: 40px;
+  width: 85%
+}
+
+@media (min-width: 40.0625em) {
+  .top-search__input {
+    border: 1px solid #ffffff;
+    font-size: 16px;
+    height: 40px;
+  }
+}
+
+@media (min-width: 658px) {
+  .top-search__input {
+    border: 1px solid #ffffff;
+    font-size: 16px;
+    height: 40px;
+    width: 600px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .top-icon__search {
+    height: 27px;
+    width: 27px;
+  }
+}
+
+@media (max-width: 40.0525em) {
+  .dfe-search__submit .dfe-icon__search .top-icon__search {
+    background-color: #1d70b8;
+    fill: black;
+    height: 27px;
+    width: 27px;
+  }
+}
+
+.top-search__submit {
+  background: #1d70b8;
+  background-color: #1d70b8;
+  display: block;
+  height: 40px;
+  width: 44px;
+  border: 0;
+  float: right;
+  font-size: inherit;
+  line-height: inherit;
+  outline: none;
+  padding: 0;
+}
+
+@media (min-width: 40.0625em) {
+  .top-search__submit {
+    background-color: #1d70b8;
+    display: block;
+    height: 40px;
+    width: 44px;
   }
 }

--- a/app/views/shared/_dfe_search_box.html.erb
+++ b/app/views/shared/_dfe_search_box.html.erb
@@ -2,14 +2,16 @@
   <div class="dfe-width-container">
     <div class="dfe-header__search-wrap" id="wrap-search">
         <form class="narrow-search dfe-header__search-form" id="search" action="/search" method="get" role="search">
-          <label class="govuk-label govuk-label--m" for="search-field"><%= t("search.header_title") %></label>
-          <input class="dfe-search__input" id="search-field" name="query" placeholder="Search" type="search" autocomplete="off" value="<%= params[:query] %>">
-          <button class="dfe-search__submit" type="submit">
-            <svg class="dfe-icon dfe-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
-              <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-            </svg>
-            <span class="govuk-visually-hidden"><%= t("shared.dfe_search.search") %></span>
-          </button>
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-label--m" for="search-field"><%= t("search.header_title") %></label>
+            <input class="govuk-input dfe-search__input top-search__input" id="search-field" name="query" placeholder="Search" type="search" autocomplete="off" value="<%= params[:query] %>">
+            <button class="top-search__submit" type="submit">
+              <svg class="dfe-icon dfe-icon__search top-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
+                <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+              </svg>
+              <span class="govuk-visually-hidden"><%= t("shared.dfe_search.search") %></span>
+            </button>
+          </div>
         </form>
     </div>
   </div>


### PR DESCRIPTION
Fix top search box for mobile

before
<img width="853" height="217" alt="Screenshot 2025-07-31 at 14 36 19" src="https://github.com/user-attachments/assets/e52ee92c-417c-47d9-be9b-d9c016111cb2" />

After
<img width="914" height="256" alt="Screenshot 2025-07-31 at 14 37 02" src="https://github.com/user-attachments/assets/fb7514e1-437f-4e9f-beb3-9d9c0043bf3a" />

