### PR TITLE
FB-221 - Created a new redis namespace - 'fabs_cache_store'

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,8 +46,8 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   config.cache_store = :redis_cache_store,
-                       {
-                         expires_in: I18n::Backend::Contentful::CACHE_EXPIRY,
+                       {  namespace: 'fabs_cache_store',
+                          expires_in: I18n::Backend::Contentful::CACHE_EXPIRY,
                        }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.


### PR DESCRIPTION

**Issue:** https://dfedigital.atlassian.net/browse/FB-221


**Tests:** 
**Local tests I did to confirm caching in the new redis namespace:
Proof of concept:**

**Production.rb ( I’ve set a new namespace):**
```
config.cache_store = :redis_cache_store,
           { namespace: 'fabs_cache_store',
            expires_in: I18n::Backend::Contentful::CACHE_EXPIRY,
           }
```

**On Rails console:**
```
CACHE_KEY = "contentful_translations".freeze
CACHE_EXPIRY = ENV.fetch("RAILS_CACHE_EXPIRY_IN_SECONDS", "=").to_i
entries = ::ContentfulClient.entries(
 content_type: "translation",
 limit: 1000
)
cached_translations = I18n::Utils.unflatten_translations(entries)
Rails.cache.write(CACHE_KEY, cached_translations, expires_in: CACHE_EXPIRY)
```

**On Redis-cli:**
```
127.0.0.1:6379> SCAN 0 MATCH fabs_cache_store:* COUNT 100
1) "0"
2) 1) "fabs_cache_store:contentful_translations"
  2) "fabs_cache_store:foo"

The following gets me all the contentful_translations:
127.0.0.1:6379> GET fabs_cache_store:contentful_translations
```