### PR TITLE
FB-404 - Update the details page CTA button

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,16 +68,19 @@ Rails.application.configure do
     # Setting I18n backend with YAML and exception handler
     yaml_backend = I18n::Backend::Simple.new
 
-    backend_chain =
-      begin
-        # Use Contentful with YAML fallback
-        contentful_backend = I18n::Backend::Contentful.new
-        Rails.logger.info "I18n: Using Contentful backend with YAML fallback"
-        [contentful_backend, yaml_backend]
-      rescue StandardError => e
-        Rails.logger.warn "Failed to initialize Contentful I18n backend: #{e.message}. Falling back to YAML translations."
-        [yaml_backend]
-      end
+    # TODO: Remove the following line when caching is made available through Contentful
+    backend_chain = [yaml_backend]
+
+    # TODO: Uncomment the following block when caching is made available through Contentful
+    # begin
+    #   # Use Contentful with YAML fallback
+    #   contentful_backend = I18n::Backend::Contentful.new
+    #   Rails.logger.info "I18n: Using Contentful backend with YAML fallback"
+    #   [contentful_backend, yaml_backend]
+    # rescue StandardError => e
+    #   Rails.logger.warn "Failed to initialize Contentful I18n backend: #{e.message}. Falling back to YAML translations."
+    #   [yaml_backend]
+    # end
 
     # Chained backend creation
     I18n.backend = I18n::Backend::Chain.new(*backend_chain)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,5 +86,5 @@ en:
       all_buying_options_section_title: DfE-approved
       all_buying_options_title: All buying options
     show:
-      cta: Visit the %{title} website
+      cta: Visit the provider’s website
       section_title: Buying option

--- a/spec/features/solutions_spec.rb
+++ b/spec/features/solutions_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Solutions pages", :vcr, type: :feature do
   context "when displaying call to action button" do
     it "displays the default CTA text when no custom CTA is provided" do
       visit solution_path("it-hardware")
-      expect(page).to have_link("Visit the IT Hardware website", class: "govuk-button")
+      expect(page).to have_link("Visit the provider’s website", class: "govuk-button")
     end
 
     it "displays the custom CTA text when provided" do


### PR DESCRIPTION
Issue: https://dfedigital.atlassian.net/browse/FB-404
- The default CTA on all details pages now reads ‘Visit the provider’s website'
- changing production.rb on staging to pick up from en.yml file than contentful
- Added some TODO comments