### PR TITLE
FB-443 Fix white gap in homepage header on Safari

### DIFF
--- a/app/views/shared/_dfe_homepage_header.html.erb
+++ b/app/views/shared/_dfe_homepage_header.html.erb
@@ -1,12 +1,10 @@
 <header class="dfe-header dfe-header--homepage" data-module="govuk-header">
   <%= render "shared/dfe_logo_and_menu" %>
   <%= render "shared/dfe_search_box"%>
-  <div class="govuk-!-margin-bottom-6">
-    <%= render "shared/dfe_service_navigation" %>
-  </div>
+  <%= render "shared/dfe_service_navigation" %>
 </header>
 
-<section class="dfe-page-hero dfe-header">
+<section class="dfe-page-hero dfe-header govuk-!-padding-top-6">
     <div class="dfe-width-container hero-text-container">
       <div class="dfe-grid-row">
         <div class="dfe-grid-column-two-thirds">


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/FB-443

Fix white gap in homepage header on Safari

Bug:
<img width="1814" height="458" alt="Screenshot 2025-09-11 at 9 59 35 am" src="https://github.com/user-attachments/assets/34dd7a58-6b9c-4bbe-9e68-0363944d1b31" />


Fixed:

<img width="1806" height="457" alt="Screenshot 2025-09-11 at 9 59 43 am" src="https://github.com/user-attachments/assets/f67730ed-51ed-4986-92c8-4a981221ac43" />
