### PR TITLE
Fix link font size in Markdown helper

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -17,7 +17,7 @@ module MarkdownHelper
       end
     end
 
-    doc = update_class(doc, "a[href]", "govuk-link govuk-body-s")
+    doc = update_class(doc, "a[href]", "govuk-link")
     doc = update_class(doc, "img", "govuk-!-width-full")
     doc.to_html.html_safe
   end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe MarkdownHelper, type: :helper do
     it "adds external link attributes to links" do
       markdown = "[Internal](/internal) [External](https://example.com)"
       html = helper.render_markdown_to_html(markdown)
-      expect(html).to include('<a href="/internal" class="govuk-link govuk-body-s">Internal</a>')
-      expect(html).to include('<a href="https://example.com" target="_blank" rel="noopener noreferrer" class="govuk-link govuk-body-s">External</a>')
+      expect(html).to include('<a href="/internal" class="govuk-link">Internal</a>')
+      expect(html).to include('<a href="https://example.com" target="_blank" rel="noopener noreferrer" class="govuk-link">External</a>')
     end
 
     it "add the correct css class for h2 and paragraph tags" do


### PR DESCRIPTION
Fix link font size in Markdown helper to be the same as body text.