### PR TITLE
Bugfix - Check if banner image exists before trying to render it

### DIFF
--- a/app/views/categories/_energy_banner.html.erb
+++ b/app/views/categories/_energy_banner.html.erb
@@ -4,6 +4,8 @@
     <p class="govuk-body energy-banner__description"><%= banner.description %></p>
     <%= fabs_govuk_link_to banner.call_to_action, banner.url, class: "govuk-button govuk-button--success energy-banner__call_to_action govuk-!-margin-top-1" %>
   </div>
-  <div class="govuk-grid-column-one-half energy-banner__image" style="--bg-image: url('<%= banner.image.url %>')">
-  </div>
+  <% if banner.image.present? %>
+    <div class="govuk-grid-column-one-half energy-banner__image" style="--bg-image: url('<%= banner.image.url %>')">
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
Check if banner image exists before trying to render it. Otherwise we get this error when there is no image and this breaks the homepage - 

```
NoMethodError: undefined method 'url' for nil
  File "/app/app/views/categories/_energy_banner.html.erb", line 7, in _app_views_categories__energy_banner_html_erb___3483300101098394274_6992
```

