### PR TITLE
Fb 461 offers fixing issues

### DIFF
--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -2,7 +2,7 @@
   <% if @energy_banner %>
     <%= render partial: 'energy_banner', locals: { banner: @energy_banner } %>
   <% end %>
-  <% if @number_of_offers > 0 %>
+  <% if @featured_offers.size > 0 %>
     <h2 class="govuk-heading-m"><%= t(".offers_title") %></h2>
     <p class="description"><%= t(".offers_description") %></p>
     <% if @number_of_offers > 3  %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -21,7 +21,7 @@
         <ul class="offer-list">
           <% @featured_offers_to_show_as_bullet_points.each do |offer| %>
             <li class="offer-list-item">
-              <%= govuk_link_to offer.title, offer_path(slug: offer.slug), class: "govuk-link chevron-card__link" %>
+              <%= govuk_link_to offer.title, offer_path(slug: offer.slug), class: "govuk-link" %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
PR: https://github.com.mcas.ms/DFE-Digital/find-a-buying-solution/pull/325

Issue: https://dfedigital.atlassian.net/browse/FB-461

ISSUE 1
Removed the spurious right chevron

Before
<img width="906" height="209" alt="Screenshot 2025-09-25 at 16 33 37" src="https://github.com/user-attachments/assets/f3fa6e7e-e7c4-418b-a00f-0186e22fe03e" />

After
<img width="706" height="166" alt="Screenshot 2025-09-25 at 16 33 59" src="https://github.com/user-attachments/assets/1411efad-fc8f-4863-b74b-0498e8885318" />


ISSUE 2
Scenario:
One offer without an image & no featured offer / One offer with an image & no featured offer
Expected:
Offers section NOT displayed on the homepage and Service Navigation section displayed at the top of the page