### PR TITLE
FB-461 - offers section needs to show if offers>0 and featured_offers=0

### DIFF
--- a/app/helpers/offer_helper.rb
+++ b/app/helpers/offer_helper.rb
@@ -2,4 +2,19 @@ module OfferHelper
   def offer_cta(offer)
     offer.call_to_action.presence || t("offers.show.cta", title: offer.title)
   end
+
+  def show_browse_all_offers_link?(number_of_offers, featured_offers)
+    # Determines when to display the "Browse all offers" link.
+    # The link is shown if:
+    # 1. The total number of offers is greater than the size of the featured offers.
+    # 2. There are more than 3 featured offers, and all offers are featured.
+    number_of_offers > featured_offers.size ||
+      (featured_offers.size > 3 && number_of_offers == featured_offers.size)
+  end
+
+  def show_offers_section?(number_of_offers)
+    # Determines when to display the offers section.
+    # The link is shown only when there are 1 or more offers
+    number_of_offers.positive?
+  end
 end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -2,10 +2,10 @@
   <% if @energy_banner %>
     <%= render partial: 'energy_banner', locals: { banner: @energy_banner } %>
   <% end %>
-  <% if @featured_offers.size > 0 %>
+  <% if show_offers_section?(@number_of_offers) %>
     <h2 class="govuk-heading-m"><%= t(".offers_title") %></h2>
     <p class="description"><%= t(".offers_description") %></p>
-    <% if @number_of_offers > 3  %>
+    <% if show_browse_all_offers_link?(@number_of_offers, @featured_offers) %>
       <%= link_to  t(".browse_all_offers"), offers_path, class:"all-offers-link govuk-body underlined" %>
     <% end %>
 


### PR DESCRIPTION
Issue: 
https://dfedigital.atlassian.net/browse/FB-461

The offers section now displays the 'Offers' title and description along with the 'browse_all_offers' link on the homepage, even if there are no featured offers but there are other offers to show.

As you can see in the following image, although there are no featured offers to show either as a list/card, the offers section still shows up with Offers title , description and with the "Browse all offers' link.
<img width="942" height="130" alt="Screenshot 2025-09-26 at 13 49 12" src="https://github.com/user-attachments/assets/9639368a-d26c-4ea7-bcd8-6cd3bfd8fe28" />

