### PR TITLE
FB-467-Remove 'Buying category' text from the all offers pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
       description: Browse time-limited offers negotiated by DfE for you, so you can
         get best value.
       expires_on: Expires on
-      section_title: Buying category
+      section_title: ''
       title: Offers
     show:
       cta: Link to the offer


### PR DESCRIPTION
Added an empty string as place holder for section_title as the content manager may choose to give it a title.
<img width="1125" height="580" alt="Screenshot 2025-09-29 at 11 41 07" src="https://github.com/user-attachments/assets/e69989ab-9cfe-443f-96a2-400cacc925fc" />