### PR TITLE
CORE-340 | Add Request for Help section on home page

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1470,3 +1470,10 @@ a.all-buying-options-link {
     }
 }
 
+.no-margin {
+  margin-bottom: 0;
+}
+
+.govuk-inset-text--thin {
+  border-left-width: 6px;
+}

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,8 +1,14 @@
-
 <div class="govuk-!-margin-top-4">
   <% if @energy_banner %>
     <%= render partial: 'energy_banner', locals: { banner: @energy_banner } %>
   <% end %>
+
+  <div class="govuk-inset-text govuk-inset-text--thin">
+    <h2 class="govuk-heading-m no-margin"><%= t(".not_sure_title") %></h2>
+    <p class="govuk-body"><%= t(".not_sure_body") %></p>
+    <%= govuk_link_to(t(".expert_help_button"), "https://www.get-help-buying-for-schools.service.gov.uk/procurement-support", class: "cta govuk-button") %>
+  </div>
+
   <% if @featured_offers.present? %>
     <h2 class="govuk-heading-m"><%= t(".offers_title") %></h2>
     <div class="dfe-grid-container offers-grid-container">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,12 +8,13 @@ en:
       clear_all_filters: Clear all filters
       remove_filter: Remove filter
     index:
+      expert_help_button: Get expert buying help
+      not_sure_body: Our buying team can help you choose the right way to buy for
+        your school
+      not_sure_title: Not sure where to start?
       offers_title: DfE featured
       procurement_support: I need something else (opens in a new tab)
       title: DfE-approved buying options by category
-      not_sure_title: Not sure where to start?
-      not_sure_body: Our buying team can help you choose the right way to buy for your school
-      expert_help_button: Get expert buying help
     show:
       apply: Apply
       dfe_standfirst: These DfE buying options provide compliant, best value for schools

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,9 @@ en:
       offers_title: DfE featured
       procurement_support: I need something else (opens in a new tab)
       title: DfE-approved buying options by category
+      not_sure_title: Not sure where to start?
+      not_sure_body: Our buying team can help you choose the right way to buy for your school
+      expert_help_button: Get expert buying help
     show:
       apply: Apply
       dfe_standfirst: These DfE buying options provide compliant, best value for schools

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe "Categories pages", :vcr, type: :request do
     it "does not display categories without solutions" do
       expect(response.body).not_to include("category-without-any-solution")
     end
+
+    it "displays new request for help content", vcr: { cassette_name: "Categories_pages/GET_/sets_default_HTML_title_tag" } do
+      expect(response.body).to include("Not sure where to start?")
+      expect(response.body).to include("Our buying team can help you choose the right way to buy for your school")
+      expect(response.body).to include("Get expert buying help")
+    end
   end
 
   describe "GET /categories/:slug" do


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CORE-340

Add new section for Request for Help section on GHBS home page for Heroku

<img width="1084" height="505" alt="image" src="https://github.com/user-attachments/assets/b8de88aa-934a-44c1-b269-d3189517bef4" />
